### PR TITLE
data service: Add simple blue/green deployment to docker-compose.yml, add Caddyfiles to git

### DIFF
--- a/svcs/data/caddy/Caddyfile.blue
+++ b/svcs/data/caddy/Caddyfile.blue
@@ -1,28 +1,10 @@
-# The Caddyfile is an easy way to configure your Caddy web server.
-#
-# Unless the file starts with a global options block, the first
-# uncommented line is always the address of your site.
-#
-# To use your own domain name (with automatic HTTPS), first make
-# sure your domain's A/AAAA DNS records are properly pointed to
-# this machine's public IP, then replace ":80" below with your
-# domain name.
+# Caddy configuration file for Soundscape back-end services 
 
-#:80 {
-    # Set this path to your site's directory.
-#	root * /usr/share/caddy
+# There are two Caddy configuration files that should be placed in /etc/caddy on
+# the server. A symbolic link /etc/caddy/Caddyfile points to the current active
+# configuration. The only difference between the two configurations is the port
+# number to forward the request to, 8081 for blue and 8082 for green.
 
-    # Enable the static file server.
-#	file_server
-
-    # Another common task is to set up a reverse proxy:
-    # reverse_proxy localhost:8080
-
-    # Or serve a PHP site through php-fpm:
-    # php_fastcgi localhost:9000
-#}
-
-# Soundscape back-end services
 tiles.soundscape.services {
     reverse_proxy localhost:8081 {
         header_up X-Real-IP {remote_host}

--- a/svcs/data/caddy/Caddyfile.blue
+++ b/svcs/data/caddy/Caddyfile.blue
@@ -1,0 +1,44 @@
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace ":80" below with your
+# domain name.
+
+#:80 {
+    # Set this path to your site's directory.
+#	root * /usr/share/caddy
+
+    # Enable the static file server.
+#	file_server
+
+    # Another common task is to set up a reverse proxy:
+    # reverse_proxy localhost:8080
+
+    # Or serve a PHP site through php-fpm:
+    # php_fastcgi localhost:9000
+#}
+
+# Soundscape back-end services
+tiles.soundscape.services {
+    reverse_proxy localhost:8081 {
+        header_up X-Real-IP {remote_host}
+    }
+    header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+}
+
+newprod0.openscape.io {
+    reverse_proxy localhost:8081 {
+        header_up X-Real-IP {remote_host}
+    }
+    header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+}
+
+share.soundscape.services {
+    header /.well-known/apple-app-site-association Content-Type application/json
+    root * /home/soundscape/share.soundscape.services/
+    file_server
+}

--- a/svcs/data/caddy/Caddyfile.green
+++ b/svcs/data/caddy/Caddyfile.green
@@ -1,28 +1,10 @@
-# The Caddyfile is an easy way to configure your Caddy web server.
-#
-# Unless the file starts with a global options block, the first
-# uncommented line is always the address of your site.
-#
-# To use your own domain name (with automatic HTTPS), first make
-# sure your domain's A/AAAA DNS records are properly pointed to
-# this machine's public IP, then replace ":80" below with your
-# domain name.
+# Caddy configuration file for Soundscape back-end services 
 
-#:80 {
-    # Set this path to your site's directory.
-#	root * /usr/share/caddy
+# There are two Caddy configuration files that should be placed in /etc/caddy on
+# the server. A symbolic link /etc/caddy/Caddyfile points to the current active
+# configuration. The only difference between the two configurations is the port
+# number to forward the request to, 8081 for blue and 8082 for green.
 
-    # Enable the static file server.
-#	file_server
-
-    # Another common task is to set up a reverse proxy:
-    # reverse_proxy localhost:8080
-
-    # Or serve a PHP site through php-fpm:
-    # php_fastcgi localhost:9000
-#}
-
-# Soundscape back-end services
 tiles.soundscape.services {
     reverse_proxy localhost:8082 {
         header_up X-Real-IP {remote_host}

--- a/svcs/data/caddy/Caddyfile.green
+++ b/svcs/data/caddy/Caddyfile.green
@@ -1,0 +1,44 @@
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace ":80" below with your
+# domain name.
+
+#:80 {
+    # Set this path to your site's directory.
+#	root * /usr/share/caddy
+
+    # Enable the static file server.
+#	file_server
+
+    # Another common task is to set up a reverse proxy:
+    # reverse_proxy localhost:8080
+
+    # Or serve a PHP site through php-fpm:
+    # php_fastcgi localhost:9000
+#}
+
+# Soundscape back-end services
+tiles.soundscape.services {
+    reverse_proxy localhost:8082 {
+        header_up X-Real-IP {remote_host}
+    }
+    header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+}
+
+newprod0.openscape.io {
+    reverse_proxy localhost:8082 {
+        header_up X-Real-IP {remote_host}
+    }
+    header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+}
+
+share.soundscape.services {
+    header /.well-known/apple-app-site-association Content-Type application/json
+    root * /home/soundscape/share.soundscape.services/
+    file_server
+}

--- a/svcs/data/docker-compose.yml
+++ b/svcs/data/docker-compose.yml
@@ -11,10 +11,25 @@
 #
 # Once all three components are running (PostGIS server, ingest service, tile
 # server), test by fetching a tile in your browser, e.g.:
-#   http://localhost:8080/16/18745/25070.json
+#   http://localhost:8081/16/18745/25070.json
 #
 # Helpful tool for finding other tile coordinates (the last two numbers in the
 # above URL): http://bboxfinder.com/
+
+# There are two tilesrv services defined, tilesrv-blue and tilesrv-green to
+# allow for updates without downtime. tilesrv-blue is started by default. 
+#
+# To update:
+# docker compose up --build -d tilesrv-green
+# Test tilesrv-green on localhost:8082
+# switch Caddy config:
+# sudo ln -s /etc/caddy/Caddyfile.green /etc/caddy/Caddyfile
+# sudo systemctl reload caddy
+# if everything works, bring down tilesrv-blue:
+# docker compose stop tilesrv-blue
+# docker compose rm tilesrv-blue
+#
+# For the next update swap blue and green in the instructions above.
 version: '3.8'
 
 volumes:

--- a/svcs/data/docker-compose.yml
+++ b/svcs/data/docker-compose.yml
@@ -55,14 +55,28 @@ services:
       postgis:
         condition: service_healthy
 
-  tilesrv:
+  tilesrv-blue:
     image: soundscape/tilesrv
     build:
       dockerfile: Dockerfile.tilesrv
     environment:
       - DSN=host=postgis port=5432 dbname=osm user=postgres password=secret
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8081:8080"
     depends_on:
       postgis:
         condition: service_healthy
+
+  tilesrv-green:
+    image: soundscape/tilesrv
+    build:
+      dockerfile: Dockerfile.tilesrv
+    environment:
+      - DSN=host=postgis port=5432 dbname=osm user=postgres password=secret
+    ports:
+      - "127.0.0.1:8082:8080"
+    depends_on:
+      postgis:
+        condition: service_healthy
+    # prevent tilesrv-green from starting automatically
+    profiles: ["tilesrv-green"]


### PR DESCRIPTION
This duplicates the tilesrv service in docker-compose.yml, to allow for zero downtime updates of the tile server. tilesrv-blue is started by default. 

- To update:

```
docker compose up --build -d tilesrv-green
```

- Test tilesrv-green on localhost:8082
- switch Caddy config:
```
sudo ln -s /etc/caddy/Caddyfile.green /etc/caddy/Caddyfile
sudo systemctl reload caddy
```
- if everything works, bring down tilesrv-blue:
```
docker compose stop tilesrv-blue
docker compose rm tilesrv-blue
```

This PR also restricts the 8081/8082 ports to localhost.

I chose 8081/8082 to make local testing easier since 8080 is a very common port.

This branch is already running on the production server.