### PR TITLE
Add CORS headers to Caddyfiles

### DIFF
--- a/svcs/data/caddy/Caddyfile.blue
+++ b/svcs/data/caddy/Caddyfile.blue
@@ -5,11 +5,22 @@
 # configuration. The only difference between the two configurations is the port
 # number to forward the request to, 8081 for blue and 8082 for green.
 
+(cors) {
+  @origin{args.0} header Origin {args.0}
+  header @origin{args.0} Access-Control-Allow-Origin "{args.0}"
+  header @origin{args.0} Vary Origin
+}
+
 tiles.soundscape.services {
     reverse_proxy localhost:8081 {
         header_up X-Real-IP {remote_host}
     }
     header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+    header Access-Control-Allow-Methods "GET"
+    header Access-Control-Allow-Headers "*"
+
+    # Allow requests coming from the Soundscape web client hosted on Github
+    import cors https://soundscape-community.github.io
 }
 
 newprod0.openscape.io {

--- a/svcs/data/caddy/Caddyfile.green
+++ b/svcs/data/caddy/Caddyfile.green
@@ -5,11 +5,22 @@
 # configuration. The only difference between the two configurations is the port
 # number to forward the request to, 8081 for blue and 8082 for green.
 
+(cors) {
+  @origin{args.0} header Origin {args.0}
+  header @origin{args.0} Access-Control-Allow-Origin "{args.0}"
+  header @origin{args.0} Vary Origin
+}
+
 tiles.soundscape.services {
     reverse_proxy localhost:8082 {
         header_up X-Real-IP {remote_host}
     }
     header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+    header Access-Control-Allow-Methods "GET"
+    header Access-Control-Allow-Headers "*"
+
+    # Allow requests coming from the Soundscape web client hosted on Github
+    import cors https://soundscape-community.github.io
 }
 
 newprod0.openscape.io {


### PR DESCRIPTION
I'm working on a browser-based client (#75). It's being served by Github pages at https://soundscape-community.github.io/soundscape-web-client/. It's currently broken because it can't make requests to the tile server. Modern browsers block client-side requests to a different origin unless the other origin explicitly lists the originating domain in its CORS headers. This pull request is my (untested) attempt to add the right headers to the Caddy config, based on the example at https://www.matsimitsu.com/blog/2022-01-02-serving-static-cors-json-with-caddy. If it's correct, the errors in the developer console about blocked origins should go away.