### PR TITLE
Add YouTube channel URL to About screen

### DIFF
--- a/apps/ios/GuideDogs/Code/App/AppContext.swift
+++ b/apps/ios/GuideDogs/Code/App/AppContext.swift
@@ -383,6 +383,10 @@ extension AppContext {
             return URL(string: "https://soundscape.services")!
         }
     
+        static func youtubeURL(for locale: Locale) -> URL {
+            return URL(string: "https://www.youtube.com/@SoundscapeCommunity")!
+        }
+
         static let companySupportURL = URL(string: "https://discord.gg/XakpNsVMBZ")!
         
         static let accessibilityFrance = URL(string: "https://soundscape.services")!

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/AboutViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/AboutViewController.swift
@@ -51,7 +51,8 @@ class AboutApplicationViewController: BaseTableViewController {
             AboutLinkCellModel(localizedTitle: GDLocalizedString("settings.about.title.whats_new"), segue: "ShowVersionHistorySegue"),
             AboutLinkCellModel(localizedTitle: GDLocalizationUnnecessary("Privacy Policy"), url: AppContext.Links.privacyPolicyURL(for: LocalizationContext.currentAppLocale), event: "about.privacy_policy"),
             AboutLinkCellModel(localizedTitle: GDLocalizationUnnecessary("Services Agreement"), url: AppContext.Links.servicesAgreementURL(for: LocalizationContext.currentAppLocale), event: "about.services_agreement"),
-            AboutLinkCellModel(localizedTitle: GDLocalizedString("settings.about.title.copyright"), segue: "ShowThirdPartyNoticesSegue")
+            AboutLinkCellModel(localizedTitle: GDLocalizedString("settings.about.title.copyright"), segue: "ShowThirdPartyNoticesSegue"),
+            AboutLinkCellModel(localizedTitle: GDLocalizationUnnecessary("YouTube Channel"), url: AppContext.Links.youtubeURL(for: LocalizationContext.currentAppLocale), event: "about.youtube_channel")
         ]
         
         if LocalizationContext.currentAppLocale == Locale.frFr {


### PR DESCRIPTION
Per @jchudge request. Fortunately only changing code was necessary, not visually manipulating Xcode storyboards.