### PR TITLE
Clear cached map data after update and remove the prompt to delete markers when clearing data

### DIFF
--- a/apps/ios/GuideDogs/Code/App/AppContext.swift
+++ b/apps/ios/GuideDogs/Code/App/AppContext.swift
@@ -205,59 +205,6 @@ class AppContext {
     }
     
     // MARK: Actions
-
-    /// Clears the map data cache
-    /// fixme: probably not the best place for this, but it is needed for updates 
-    /// from version 1.1.2
-    func clearMapDataCache() {
-        // copied from StatusViewController.swift
-        AppContext.shared.eventProcessor.hush(playSound: false)
-        guard let database = try? RealmHelper.getDatabaseRealm() else {
-            GDLogSpatialDataError("Error attempting to get database data!")
-            return
-        }
-        
-        var storedAddresses: [Address] = []
-        for por in database.objects(ReferenceEntity.self) {
-            if let entity = por.getPOI() as? Address, storedAddresses.contains(where: { $0.key == entity.key }) == false {
-                // Copy the address
-                storedAddresses.append(Address(value: entity))
-            }
-        }
-        
-        let success = AppContext.shared.spatialDataContext.clearCache()
-        
-        GDATelemetry.track("settings.clear_cache", with: ["keep_user_data": String(true)])
-        
-        guard success else {
-            GDLogSpatialDataError("Error attempting to delete cached data!")
-            return
-        }
-        
-        guard storedAddresses.count > 0 else {
-            GDLogSpatialDataWarn("Cached data deleted")
-            return
-        }
-        
-        // Save stored addresses
-        guard let cache = try? RealmHelper.getCacheRealm() else {
-            GDLogSpatialDataError("Cached data deleted, but couldn't get cache realm to restore addresses!")
-            return
-        }
-        
-        do {
-            try cache.write {
-                for address in storedAddresses {
-                    cache.create(Address.self, value: address, update: .modified)
-                }
-            }
-        } catch {
-            GDLogSpatialDataError("Cached data deleted, but couldn't restore addresses!")
-            return
-        }
-        
-        GDLogSpatialDataWarn("Cached data deleted and addresses restored")
-    }
     
     /// Starts the core components of the app including the sound context, the geolocation context,
     /// and the spatial data context. If the app is launched into the background by the system (e.g.
@@ -292,13 +239,6 @@ class AppContext {
         DeviceMotionManager.shared.startDeviceMotionUpdates()
         cloudKeyValueStore.start()
         spatialDataContext.start()
-        
-        // if the app was updated or there is no lastRunVersion, clear the cache
-        let lastRunVersion = UserDefaults.standard.string(forKey: "lastRunVersion") ?? ""
-        if lastRunVersion != AppContext.appVersion {
-            clearMapDataCache()
-            UserDefaults.standard.set(AppContext.appVersion, forKey: "lastRunVersion")
-        }
         
         // Do not play the app launch sound if onboarding is in-progress
         if !(eventProcessor.activeBehavior is OnboardingBehavior) {

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
@@ -191,14 +191,26 @@ extension StatusTableViewController {
             if SettingsContext.shared.automaticCalloutsEnabled {
                 self.reenableCalloutsAfterReload = true
                 SettingsContext.shared.automaticCalloutsEnabled = false
-            }
+            }    
+            self.performSegue(withIdentifier: Segue.showLoadingModal, sender: self)
             
-            self.displayMarkersPrompt()
+            // Check that tiles can be downloaded before we attempt to delete the cache
+            AppContext.shared.spatialDataContext.checkServiceConnection { [weak self] (success) in
+                guard success else {
+                    self?.displayUnableToClearCacheWarning()
+                    return
+                }
+                
+                // Clear the cache and keep the markers
+                self?.clearCache(false)
+            }
         }))
         
         present(alert, animated: true, completion: nil)
     }
     
+    /// ask the user if they want to keep the markers.
+    /// This is not used, but could be reenabled for debug builds in the future.
     private func displayMarkersPrompt() {
         let alert = UIAlertController(title: GDLocalizedString("settings.clear_cache.markers.alert_title"),
                                       message: GDLocalizedString("settings.clear_cache.markers.alert_message"),


### PR DESCRIPTION

* because of a bug in version 1.1.2, it is necessary to clear the map data after updating to 1.1.3, so this is done automatically

* It is too easy to accidentally delete markers when clearing data, so the prompt has been removed

* version 1.1.3 build 24