### PR TITLE
Fix beacon distance callouts at geofence transitions

### DIFF
--- a/apps/ios/GuideDogs/Code/App/Settings/SettingsContext.swift
+++ b/apps/ios/GuideDogs/Code/App/Settings/SettingsContext.swift
@@ -380,6 +380,8 @@ class SettingsContext {
         }
         set {
             userDefaults.set(newValue, forKey: Keys.leaveImmediateVicinityDistance)
+            // Ensure leave is always 10m greater than enter
+            userDefaults.set(newValue - 15.0, forKey: Keys.enterImmediateVicinityDistance)
         }
     }
     
@@ -389,6 +391,8 @@ class SettingsContext {
         }
         set {
             userDefaults.set(newValue, forKey: Keys.enterImmediateVicinityDistance)
+            // Ensure leave is always 15m greater than enter
+            userDefaults.set(newValue + 15.0, forKey: Keys.leaveImmediateVicinityDistance)
         }
     }
 }

--- a/apps/ios/GuideDogs/Code/App/Settings/SettingsContext.swift
+++ b/apps/ios/GuideDogs/Code/App/Settings/SettingsContext.swift
@@ -380,8 +380,8 @@ class SettingsContext {
         }
         set {
             userDefaults.set(newValue, forKey: Keys.leaveImmediateVicinityDistance)
-            // Ensure leave is always 10m greater than enter
-            userDefaults.set(newValue - 15.0, forKey: Keys.enterImmediateVicinityDistance)
+            // Ensure leave is always 15m greater than enter
+            userDefaults.set(max(newValue - 15.0, 0.0), forKey: Keys.enterImmediateVicinityDistance)
         }
     }
     

--- a/apps/ios/GuideDogs/Code/Behaviors/Default/BeaconCalloutGenerator.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Default/BeaconCalloutGenerator.swift
@@ -237,7 +237,7 @@ class BeaconCalloutGenerator: AutomaticGenerator, ManualGenerator {
         }
         
         let causedAudioDisabled = event.beaconWasEnabled && !event.beaconIsEnabled
-        guard let destinations = getCalloutsForBeacon(nearby: event.location, origin: .beaconGeofence, causedAudioDisable: causedAudioDisabled) else {
+        guard let destinations = getCalloutsForBeacon(nearby: event.location, origin: .beaconGeofence, causedAudioDisable: causedAudioDisabled, didExitGeofence: !event.didEnter) else {
             return nil
         }
         
@@ -261,7 +261,7 @@ class BeaconCalloutGenerator: AutomaticGenerator, ManualGenerator {
         return group
     }
     
-    private func getCalloutsForBeacon(nearby location: CLLocation, origin: CalloutOrigin, causedAudioDisable: Bool = false) -> [DestinationCallout]? {
+    private func getCalloutsForBeacon(nearby location: CLLocation, origin: CalloutOrigin, causedAudioDisable: Bool = false, didExitGeofence: Bool = false) -> [DestinationCallout]? {
         // Check if destination callouts are enabled
         guard settings.destinationSenseEnabled else {
             GDLogAutoCalloutInfo("Skipping beacon auto callouts. Beacon callouts are not enabled.")
@@ -271,6 +271,16 @@ class BeaconCalloutGenerator: AutomaticGenerator, ManualGenerator {
         // Check if a destination is currently set
         guard let key = destinationKey else {
             return nil
+        }
+        
+        /// Only play "Beacon within x units" callouts when entering (not exitinhg) beacon geofence. For large values of
+        /// enterImmediateVicinityDistance, when exiting a geofence, the auto callouts will immediately announce a
+        /// "Beacon: x units" value greater than the geofence radius, and we don't want to mistakenly imply we're
+        /// moving towards the beacon.
+        if origin == .beaconGeofence {
+            guard !didExitGeofence else {
+                return nil
+            }
         }
         
         // If the callout is not coming from .auto, there are no additional checks to make


### PR DESCRIPTION
There was a very subtle issue with how I implemented the configurable beacon immediate-vicinity distance (#102 ). The original non-configurable implementation had two distance threshold constants, one for entering the vicinity (15m) and one for exiting (30m). The setting I added was only for the first constant, which meant you could set an enter-vicinity distance _greater_ than the exit-vicinity distance. When this was true, the region considered "near" the beacon was no longer a circle drawn around the location, but a donut-shaped area. This led to the weird callout behavior @fraziercarr observed, where walking towards the beacon led to repeated callouts of "Beacon within x units," which would be played each time the user crossed in or out of the donut. I've now updated it so that the exit-vicinity distance is always set to the enter-vicinity distance plus 15m, ensuring the exit-vicinity distance is always the outer of the two circles.

Fixing this revealed another bug. When the enter-vicinity distance was set to larger values (25m+), when walking away from the beacon, you would hear something like "Beacon: 110 feet" before "Beacon within 80ft," which was very confusing since it implied you were walking in the opposite direction. The periodic "Beacon: 110 feet" distance callouts were being prioritized over the "Beacon within 80ft" callout played only when entering or exiting the beacon vicinity. This was because large vicinity radii exceed the normal interval at which distance callouts are announced (50m), and periodic distance callouts are disabled when you are within the beacon vicinity, so the periodic distance callouts were overdue by the time you exited the beacon vicinity. I addressed this by only playing the "Beacon within x units" callouts when entering (not exiting) the beacon vicinity.