### PR TITLE
Fix to Filter search on distance

### DIFF
--- a/apps/ios/GuideDogs/Code/App/Framework Extensions/Base Type Extensions/Array+POI.swift
+++ b/apps/ios/GuideDogs/Code/App/Framework Extensions/Base Type Extensions/Array+POI.swift
@@ -20,6 +20,16 @@ extension Array where Element == POI {
         return queue.pois
     }
     
+    func sorted(byDistanceFrom location: CLLocation) -> [POI] {
+         // Storing the poi with its distance from current location
+        let poisWithDistance = self.map { poi in
+            (poi: poi, distance: location.distance(from: CLLocation(latitude: poi.centroidLatitude, longitude: poi.centroidLongitude)))
+        }
+        // Sort the array based on the distance, then extract the POIs in sorted order
+        let sortedPoisWithDistance = poisWithDistance.sorted { $0.distance < $1.distance }
+        return sortedPoisWithDistance.map { $0.poi }
+    }
+    
     func filtered(by filterPredicate: FilterPredicate, maxLength: Int? = nil) -> [POI] {
         var pois: [POI] = []
         

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -207,6 +207,15 @@ extension SearchResultsUpdater: UISearchBarDelegate {
                 pois.append(GenericLocation(lat: lat!, lon: long!, name: result.name!, address: address))
             }
         }
+        
+        if let currentLocation = self.location {
+            pois.sort(by: { (lhs, rhs) -> Bool in
+                let loc1 = CLLocation(latitude: lhs.centroidLatitude, longitude: lhs.centroidLongitude)
+                let loc2 = CLLocation(latitude: rhs.centroidLatitude, longitude: rhs.centroidLongitude)
+                return currentLocation.distance(from: loc1) < currentLocation.distance(from: loc2)
+            })
+        }
+        
         delegate?.searchResultsDidUpdate(pois, searchLocation: self.location)
     }
     

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -209,11 +209,13 @@ extension SearchResultsUpdater: UISearchBarDelegate {
         }
         
         if let currentLocation = self.location {
-            pois.sort(by: { (lhs, rhs) -> Bool in
-                let loc1 = CLLocation(latitude: lhs.centroidLatitude, longitude: lhs.centroidLongitude)
-                let loc2 = CLLocation(latitude: rhs.centroidLatitude, longitude: rhs.centroidLongitude)
-                return currentLocation.distance(from: loc1) < currentLocation.distance(from: loc2)
-            })
+            // Storing the poi with its distance from current location
+            let poisWithDistance = pois.map { poi in
+                (poi: poi, distance: currentLocation.distance(from: CLLocation(latitude: poi.centroidLatitude, longitude: poi.centroidLongitude)))
+            }
+            // Sort the array based on the distance, then extract the POIs in sorted order
+            let sortedPoisWithDistance = poisWithDistance.sorted { $0.distance < $1.distance }
+            pois = sortedPoisWithDistance.map { $0.poi }
         }
         
         delegate?.searchResultsDidUpdate(pois, searchLocation: self.location)

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -209,13 +209,7 @@ extension SearchResultsUpdater: UISearchBarDelegate {
         }
         
         if let currentLocation = self.location {
-            // Storing the poi with its distance from current location
-            let poisWithDistance = pois.map { poi in
-                (poi: poi, distance: currentLocation.distance(from: CLLocation(latitude: poi.centroidLatitude, longitude: poi.centroidLongitude)))
-            }
-            // Sort the array based on the distance, then extract the POIs in sorted order
-            let sortedPoisWithDistance = poisWithDistance.sorted { $0.distance < $1.distance }
-            pois = sortedPoisWithDistance.map { $0.poi }
+            pois = pois.sorted(byDistanceFrom: currentLocation)
         }
         
         delegate?.searchResultsDidUpdate(pois, searchLocation: self.location)


### PR DESCRIPTION
Added a sorting code snippet after forming the pois array, when updating search results, so all results are sorted by distance from current location.