### PR TITLE
Configurable tile server URL

### DIFF
--- a/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
@@ -544,6 +544,12 @@
 // MARK: Settings (Troubleshooting)
 //------------------------------------------------------------------------------
 
+/* Title of the table section that allows user to set the tile server URL. */
+"troubleshooting.tile_server_url" = "Tile Server URL";
+
+/* Explanation of the tile server URL setting. {NumberedPlaceholder="Soundscape"} */
+"troubleshooting.tile_server_url.explanation" = "This is the server from which Soundscape retrieves map data. You normally should not need to change this unless you are developing or testing Soundscape.";
+
 /* Title of the table section that contains info about the current accuracy of the phone's GPS signal provided by Apple's Location Services feature. */
 "troubleshooting.gps_status" = "Location Accuracy";
 

--- a/apps/ios/GuideDogs/Code/App/Settings/SettingsContext.swift
+++ b/apps/ios/GuideDogs/Code/App/Settings/SettingsContext.swift
@@ -31,6 +31,7 @@ class SettingsContext {
         fileprivate static let appUseCount               = "GDAAppUseCount"
         fileprivate static let newFeaturesLastDisplayedVersion = "GDANewFeaturesLastDisplayedVersion"
         fileprivate static let clientIdentifier          = "GDAUserDefaultClientIdentifier"
+        fileprivate static let servicesHostName          = "GDAServicesHostName"
         fileprivate static let metricUnits               = "GDASettingsMetric"
         fileprivate static let locale                    = "GDASettingsLocaleIdentifier"
         fileprivate static let voiceID                   = "GDAAppleSynthVoice"
@@ -85,6 +86,7 @@ class SettingsContext {
         userDefaults.register(defaults: [
             Keys.appUseCount: 0,
             Keys.newFeaturesLastDisplayedVersion: "0.0.0",
+            Keys.servicesHostName: "https://tiles.soundscape.services",
             Keys.metricUnits: Locale.current.usesMetricSystem,
             Keys.speakingRate: 0.55,
             Keys.beaconVolume: 0.75,
@@ -160,6 +162,15 @@ class SettingsContext {
         }
         set(newValue) {
             userDefaults.set(newValue, forKey: Keys.clientIdentifier)
+        }
+    }
+    
+    var servicesHostName: String {
+        get {
+            return userDefaults.string(forKey: Keys.servicesHostName)!
+        }
+        set(newValue) {
+            userDefaults.set(newValue, forKey: Keys.servicesHostName)
         }
     }
     

--- a/apps/ios/GuideDogs/Code/App/Settings/SettingsContext.swift
+++ b/apps/ios/GuideDogs/Code/App/Settings/SettingsContext.swift
@@ -86,7 +86,6 @@ class SettingsContext {
         userDefaults.register(defaults: [
             Keys.appUseCount: 0,
             Keys.newFeaturesLastDisplayedVersion: "0.0.0",
-            Keys.servicesHostName: "https://tiles.soundscape.services",
             Keys.metricUnits: Locale.current.usesMetricSystem,
             Keys.speakingRate: 0.55,
             Keys.beaconVolume: 0.75,
@@ -167,7 +166,14 @@ class SettingsContext {
     
     var servicesHostName: String {
         get {
-            return userDefaults.string(forKey: Keys.servicesHostName)!
+            // Allow URL to be reset to default when it is cleared
+            if let servicesHostName = userDefaults.string(forKey: Keys.servicesHostName), !servicesHostName.isEmpty {
+                return servicesHostName
+            } else {
+                let servicesHostName = "https://tiles.soundscape.services"
+                userDefaults.set(servicesHostName, forKey: Keys.servicesHostName)
+                return servicesHostName
+            }
         }
         set(newValue) {
             userDefaults.set(newValue, forKey: Keys.servicesHostName)

--- a/apps/ios/GuideDogs/Code/Data/Services/Helpers/ServiceModel.swift
+++ b/apps/ios/GuideDogs/Code/Data/Services/Helpers/ServiceModel.swift
@@ -33,8 +33,6 @@ class ServiceModel {
     /// String for identifying errors that originate from Realm
     static let errorRealm = "GDAHTTPErrorRealm"
     
-    /// Domain name to resolve for production services
-    private static let productionServicesHostName = "https://tiles.soundscape.services"
     /// Domain part of the URL for learning resources
     private static let productionAssestsHostName = "https://soundscape.services"
     // Do not change `productionVoicesHostName`!
@@ -42,14 +40,6 @@ class ServiceModel {
     
     static var learningResourcesWebpage: URL {
         return URL(string: productionAssestsHostName + "/learning_resources.html")!
-    }
-
-    static var servicesHostName: String {
-        if FeatureFlag.isEnabled(.developerTools), let debugHostName = DebugSettingsContext.shared.servicesHostName, debugHostName.isEmpty == false {
-            return debugHostName
-        }
-        
-        return productionServicesHostName
     }
     
     static var assetsHostName: String {

--- a/apps/ios/GuideDogs/Code/Data/Services/OSM/OSMServiceModel.swift
+++ b/apps/ios/GuideDogs/Code/Data/Services/OSM/OSMServiceModel.swift
@@ -28,7 +28,7 @@ class OSMServiceModel: OSMServiceModelProtocol {
     private static let path = "/tiles"
     
     func getTileDataWithQueue(tile: VectorTile, categories: SuperCategories, queue: DispatchQueue, callback: @escaping OSMServiceModelProtocol.TileDataLookupCallback) {
-        let url = URL(string: "\(ServiceModel.servicesHostName)\(OSMServiceModel.path)/\(tile.zoom)/\(tile.x)/\(tile.y).json")!
+        let url = URL(string: "\(SettingsContext.shared.servicesHostName)\(OSMServiceModel.path)/\(tile.zoom)/\(tile.x)/\(tile.y).json")!
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: ServiceModel.requestTimeout)
         
         // Set the etag header

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
@@ -117,7 +117,7 @@ class StatusTableViewController: BaseTableViewController {
         switch indexPath.section {
         case Section.url:
             let cell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.gps, for: indexPath)
-            cell.textLabel?.text = ServiceModel.servicesHostName
+            cell.textLabel?.text = SettingsContext.shared.servicesHostName
             return cell
             
         case Section.gps:

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
@@ -12,9 +12,9 @@ import CocoaLumberjackSwift
 class StatusTableViewController: BaseTableViewController {
 
     private struct Section {
-        static let url = 0
-        static let gps = 1
-        static let audio = 2
+        static let gps = 0
+        static let audio = 1
+        static let url = 2
         static let cache = 3
     }
     
@@ -80,9 +80,9 @@ class StatusTableViewController: BaseTableViewController {
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
-        case Section.url:     return 1
         case Section.gps:     return 1
         case Section.audio:   return 1
+        case Section.url:     return 1
         case Section.cache:   return 1
         default:              return 0
         }
@@ -90,9 +90,9 @@ class StatusTableViewController: BaseTableViewController {
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch section {
-        case Section.url:     return GDLocalizedString("troubleshooting.tile_server_url")
         case Section.gps:     return GDLocalizedString("troubleshooting.gps_status")
         case Section.audio:   return GDLocalizedString("troubleshooting.check_audio")
+        case Section.url:     return GDLocalizedString("troubleshooting.tile_server_url")
         case Section.cache:   return GDLocalizedString("troubleshooting.cache")
         default:              return nil
         }
@@ -100,7 +100,6 @@ class StatusTableViewController: BaseTableViewController {
     
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         switch section {
-        case Section.url:     return GDLocalizedString("troubleshooting.tile_server_url.explanation")
         case Section.gps:
             if SettingsContext.shared.metricUnits {
                 return GDLocalizedString("troubleshooting.gps_status.explanation.meters")
@@ -108,6 +107,7 @@ class StatusTableViewController: BaseTableViewController {
                 return GDLocalizedString("troubleshooting.gps_status.explanation.feet")
             }
         case Section.audio: return GDLocalizedString("troubleshooting.check_audio.explanation")
+        case Section.url:     return GDLocalizedString("troubleshooting.tile_server_url.explanation")
         case Section.cache: return GDLocalizedString("troubleshooting.cache.explanation")
         default: return nil
         }
@@ -115,21 +115,6 @@ class StatusTableViewController: BaseTableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {
-        case Section.url:
-            let cell: ButtonTableViewCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
-            
-            cell.backgroundColor = Colors.Background.quaternary
-            cell.button.removeTarget(self, action: #selector(clearCacheTouchUpInside), for: .touchUpInside)
-            cell.button.removeTarget(self, action: #selector(crosscheckTouchUpInside), for: .touchUpInside)
-            cell.button.addTarget(self, action: #selector(urlTouchUpInside), for: .touchUpInside)
-            cell.button.accessibilityLabel = GDLocalizedString("troubleshooting.tile_server_url")
-            cell.button.accessibilityHint = GDLocalizedString("troubleshooting.tile_server_url.explanation")
-            cell.button.backgroundColor = Colors.Background.primary
-            cell.label.text = SettingsContext.shared.servicesHostName
-            cell.label.textAlignment = .left
-
-            return cell
-            
         case Section.gps:
             let cell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.gps, for: indexPath)
             
@@ -158,6 +143,21 @@ class StatusTableViewController: BaseTableViewController {
             cell.button.backgroundColor = Colors.Background.primary
             cell.label.text = GDLocalizedString("troubleshooting.check_audio")
             
+            return cell
+            
+        case Section.url:
+            let cell: ButtonTableViewCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
+            
+            cell.backgroundColor = Colors.Background.quaternary
+            cell.button.removeTarget(self, action: #selector(clearCacheTouchUpInside), for: .touchUpInside)
+            cell.button.removeTarget(self, action: #selector(crosscheckTouchUpInside), for: .touchUpInside)
+            cell.button.addTarget(self, action: #selector(urlTouchUpInside), for: .touchUpInside)
+            cell.button.accessibilityLabel = GDLocalizedString("troubleshooting.tile_server_url")
+            cell.button.accessibilityHint = GDLocalizedString("troubleshooting.tile_server_url.explanation")
+            cell.button.backgroundColor = Colors.Background.primary
+            cell.label.text = SettingsContext.shared.servicesHostName
+            cell.label.textAlignment = .left
+
             return cell
             
         case Section.cache:

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
@@ -116,8 +116,18 @@ class StatusTableViewController: BaseTableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {
         case Section.url:
-            let cell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.gps, for: indexPath)
-            cell.textLabel?.text = SettingsContext.shared.servicesHostName
+            let cell: ButtonTableViewCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
+            
+            cell.backgroundColor = Colors.Background.quaternary
+            cell.button.removeTarget(self, action: #selector(clearCacheTouchUpInside), for: .touchUpInside)
+            cell.button.removeTarget(self, action: #selector(crosscheckTouchUpInside), for: .touchUpInside)
+            cell.button.addTarget(self, action: #selector(urlTouchUpInside), for: .touchUpInside)
+            cell.button.accessibilityLabel = GDLocalizedString("troubleshooting.tile_server_url")
+            cell.button.accessibilityHint = GDLocalizedString("troubleshooting.tile_server_url.explanation")
+            cell.button.backgroundColor = Colors.Background.primary
+            cell.label.text = SettingsContext.shared.servicesHostName
+            cell.label.textAlignment = .left
+
             return cell
             
         case Section.gps:
@@ -140,6 +150,7 @@ class StatusTableViewController: BaseTableViewController {
             let cell: ButtonTableViewCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
             
             cell.backgroundColor = Colors.Background.quaternary
+            cell.button.removeTarget(self, action: #selector(urlTouchUpInside), for: .touchUpInside)
             cell.button.removeTarget(self, action: #selector(clearCacheTouchUpInside), for: .touchUpInside)
             cell.button.addTarget(self, action: #selector(crosscheckTouchUpInside), for: .touchUpInside)
             cell.button.accessibilityLabel = GDLocalizedString("troubleshooting.check_audio")
@@ -153,6 +164,7 @@ class StatusTableViewController: BaseTableViewController {
             let cell: ButtonTableViewCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
             
             cell.backgroundColor = Colors.Background.quaternary
+            cell.button.removeTarget(self, action: #selector(urlTouchUpInside), for: .touchUpInside)
             cell.button.removeTarget(self, action: #selector(crosscheckTouchUpInside), for: .touchUpInside)
             cell.button.addTarget(self, action: #selector(clearCacheTouchUpInside), for: .touchUpInside)
             cell.button.accessibilityLabel = GDLocalizedString("settings.clear_data")
@@ -171,6 +183,29 @@ class StatusTableViewController: BaseTableViewController {
 }
 
 extension StatusTableViewController {
+    @objc func urlTouchUpInside() {
+        let alertController = UIAlertController(title: GDLocalizedString("troubleshooting.tile_server_url"), message: nil, preferredStyle: .alert)
+        alertController.addTextField { textField in
+            textField.placeholder = SettingsContext.shared.servicesHostName
+        }
+        
+        let submitAction = UIAlertAction(title: GDLocalizedString("general.alert.done"), style: .default) { [unowned alertController] _ in
+            if let textField = alertController.textFields?.first {
+                if let userInput = textField.text, !userInput.isEmpty {
+                    SettingsContext.shared.servicesHostName = userInput
+                    // Update url button label
+                    self.tableView.reloadData()                }
+            }
+        }
+        
+        let cancelAction = UIAlertAction(title: GDLocalizedString("general.alert.cancel"), style: .cancel)
+        
+        alertController.addAction(submitAction)
+        alertController.addAction(cancelAction)
+
+        present(alertController, animated: true)
+    }
+    
     
     @objc func crosscheckTouchUpInside() {
         GDLogAppInfo("Play crosscheck audio")

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
@@ -194,13 +194,22 @@ extension StatusTableViewController {
                 if let userInput = textField.text, !userInput.isEmpty {
                     SettingsContext.shared.servicesHostName = userInput
                     // Update url button label
-                    self.tableView.reloadData()                }
+                    self.tableView.reloadData()
+                }
             }
+        }
+        
+        let resetAction = UIAlertAction(title: GDLocalizedString("general.alert.reset"), style: .destructive) { [] _ in
+            // reset SettingsContext.shared.servicesHostName to default value
+            SettingsContext.shared.servicesHostName = ""
+            // Update url button label
+            self.tableView.reloadData()
         }
         
         let cancelAction = UIAlertAction(title: GDLocalizedString("general.alert.cancel"), style: .cancel)
         
         alertController.addAction(submitAction)
+        alertController.addAction(resetAction)
         alertController.addAction(cancelAction)
 
         present(alertController, animated: true)

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
@@ -12,13 +12,16 @@ import CocoaLumberjackSwift
 class StatusTableViewController: BaseTableViewController {
 
     private struct Section {
-        static let gps = 0
-        static let audio = 1
-        static let cache = 2
+        static let url = 0
+        static let gps = 1
+        static let audio = 2
+        static let cache = 3
     }
     
     private struct CellIdentifier {
         static let gps = "GPSStatus"
+        //FIXME adding a new cell identifier requires modifying a storyboard?
+        //static let url = "TileServerURL"
     }
     
     private struct Segue {
@@ -72,11 +75,12 @@ class StatusTableViewController: BaseTableViewController {
     // MARK: - Table view data source
     
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 3
+        return 4
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
+        case Section.url:     return 1
         case Section.gps:     return 1
         case Section.audio:   return 1
         case Section.cache:   return 1
@@ -86,6 +90,7 @@ class StatusTableViewController: BaseTableViewController {
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch section {
+        case Section.url:     return GDLocalizedString("troubleshooting.tile_server_url")
         case Section.gps:     return GDLocalizedString("troubleshooting.gps_status")
         case Section.audio:   return GDLocalizedString("troubleshooting.check_audio")
         case Section.cache:   return GDLocalizedString("troubleshooting.cache")
@@ -95,6 +100,7 @@ class StatusTableViewController: BaseTableViewController {
     
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         switch section {
+        case Section.url:     return GDLocalizedString("troubleshooting.tile_server_url.explanation")
         case Section.gps:
             if SettingsContext.shared.metricUnits {
                 return GDLocalizedString("troubleshooting.gps_status.explanation.meters")
@@ -109,6 +115,11 @@ class StatusTableViewController: BaseTableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {
+        case Section.url:
+            let cell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.gps, for: indexPath)
+            cell.textLabel?.text = ServiceModel.servicesHostName
+            return cell
+            
         case Section.gps:
             let cell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.gps, for: indexPath)
             

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
@@ -20,8 +20,6 @@ class StatusTableViewController: BaseTableViewController {
     
     private struct CellIdentifier {
         static let gps = "GPSStatus"
-        //FIXME adding a new cell identifier requires modifying a storyboard?
-        //static let url = "TileServerURL"
     }
     
     private struct Segue {


### PR DESCRIPTION
Adds a field under Settings > Troubleshooting showing the tile server URL. Selecting this field launches a dialog where the user can set their own URL.

We might want to add a reset button to revert to the default, since this is an action a user might well want to do but likely wouldn't remember the standard URL.

Closes #3.