### PR TITLE
Log metrics in ingest.py

### DIFF
--- a/svcs/data/docker-compose.yml
+++ b/svcs/data/docker-compose.yml
@@ -67,6 +67,11 @@ services:
     volumes:
       - tiles:/tiles
       - ./extra_data:/extra_data
+    # You only need to expose the port from this container if you want to
+    # view the Prometheus metrics endpoint from your browser, accessible at
+    # http://localhsot:8083/
+    #ports:
+    #  - "127.0.0.1:8083:8000"
     depends_on:
       postgis:
         condition: service_healthy

--- a/svcs/data/requirements.txt
+++ b/svcs/data/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp==3.9.1
 aiopg==1.4.0
+prometheus-client==0.21.1
 psycopg2-binary==2.9.9


### PR DESCRIPTION
As a first step towards #71, for the five ingest phases that were already being measured and discarded, the duration and last execution time are now logged as Prometheus metrics. The ingest container exposes these metrics over HTTP in the same manner as the tile server already did, though on a port that isn't exposed to the host.

Next we'll want to set up monitoring and alerting based on the values. @RDMurray what were the steps involved to get Uptime Kuma posting to Slack? I could imagine doing something similar from an [Alertmanager ](https://prometheus.io/docs/alerting/latest/alertmanager/) container added to our docker-compose setup.