### PR TITLE
Announce NaviLens availability in spoken callouts

### DIFF
--- a/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
@@ -2507,6 +2507,9 @@
 /*  */
 "directions.name_distance" = "%1$@, %2$@";
 
+/*  */
+"directions.navilens_available" = "NaviLens available";
+
 
 /*  */
 "distance.format.m" = "%@ m";

--- a/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
@@ -1869,6 +1869,9 @@
 /* Notification, %1$@ is a point of interest and %2$@ is a physical address, "<Some Place>. Street address is <Some Address>. Distance unknown." {NumberedPlaceholder="%1$@", "%2$@"} */
 "directions.name_street_address" = "%1$@. Street address is %2$@. Distance unknown.";
 
+/* Notification at locations with NaviLens codes */
+"directions.navilens_available" = "NaviLens available";
+
 //------------------------------------------------------------------------------
 // MARK: Directions (Traveling with Cardinal Directions)
 //------------------------------------------------------------------------------

--- a/apps/ios/GuideDogs/Assets/Localization/es-ES.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/es-ES.lproj/Localizable.strings
@@ -2497,6 +2497,9 @@
 /*  */
 "directions.name_distance" = "%1$@, %2$@";
 
+/*  */
+"directions.navilens_available" = "NaviLens disponible";
+
 
 /*  */
 "distance.format.m" = "%@ m";

--- a/apps/ios/GuideDogs/Code/Behaviors/Default/Callouts/POICallout.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Default/Callouts/POICallout.swift
@@ -171,6 +171,11 @@ struct POICallout: POICalloutProtocol {
             sounds.append(TTSSound(formattedName, at: soundLocation))
         }
         
+        // Announce "NaviLens available" for NaviLens-enabled locations
+        if poi.superCategory == "navilens" {
+            sounds.append(TTSSound(GDLocalizedString("directions.navilens_available"), at: soundLocation))
+        }
+        
         if let annotation = marker?.annotation, annotation.isEmpty == false {
             sounds.append(TTSSound(annotation, at: soundLocation))
         }

--- a/svcs/data/non_osm_scripts/convert_csv.py
+++ b/svcs/data/non_osm_scripts/convert_csv.py
@@ -41,9 +41,7 @@ if __name__ == "__main__":
                     "longitude": row.pop("stop_lon"),
 
                     #TODO Generalize beyond bus stops
-                    "name": "NaviLens available: " + (
-                        row.pop("stop_desc") or row.pop("stop_name")
-                    ),
+                    "name": row.pop("stop_desc") or row.pop("stop_name"),
 
                     # Soundscape app expects these as top-level GeoJSON properties
                     "feature_type": "highway",

--- a/svcs/data/non_osm_scripts/convert_gpx.py
+++ b/svcs/data/non_osm_scripts/convert_gpx.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
                     "longitude": wpt.get('lon'),
 
                     #TODO Generalize beyond bus stops
-                    "name": "NaviLens available: " + name,
+                    "name": name,
 
                     # Soundscape app expects these as top-level GeoJSON properties
                     "feature_type": "highway",

--- a/svcs/data/utilities/random_tile_server.py
+++ b/svcs/data/utilities/random_tile_server.py
@@ -43,7 +43,7 @@ def random_feature(lat, lon, osm_id):
     # Create a mixture of normal and Navilens-enabled bus stops
     properties = {"name": "Normal",}
     if random.choice([True, False]):
-        properties["name"] = "Navilens-enabled"
+        properties["name"] = "Navilens"
         properties["qr_code:navilens"] = "yes"
 
     # Return a bus stop at the given latitude + longitude


### PR DESCRIPTION
Instead of hard-coding "NaviLens-enabled" into location names, the app will add text to the spoken callouts to indicate NaviLens is available. This allows the text to be localized to the user's language. 