### PR TITLE
Add NaviLens button to app home screen when in range

### DIFF
--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/CompositeRecommender.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/CompositeRecommender.swift
@@ -25,10 +25,12 @@ class CompositeRecommender: Recommender {
     private enum Component: Int, CaseIterable {
         // `rawValue` represents the recommender's
         // priority
+        case navilens
         case route
         
         var recommender: Recommender {
             switch self {
+            case .navilens: return NavilensRecommender()
             case .route: return RouteRecommender()
             }
         }

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommender.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommender.swift
@@ -1,0 +1,94 @@
+//
+//  NavilensRecommender.swift
+//  Soundscape
+//
+//  Copyright (c) Soundscape Community.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+import CoreLocation
+
+/*
+ * This recommender listens for location updates and queries for nearby NaviLens-enabled POIs.
+ * If there is such a POI nearby the given location, the recommender publishes a corresponding
+ * `NavilensRecommenderView`, else the recommender publishes a `nil` value.
+ *
+ */
+class NavilensRecommender: Recommender {
+    
+    // Properties
+    
+    let publisher: CurrentValueSubject<(() -> AnyView)?, Never> = .init(nil)
+    private var listeners: [AnyCancellable] = []
+    
+    // MARK: Initialization
+    
+    init() {
+        self.publishCurrentValue()
+        
+        listeners.append(NotificationCenter.default.publisher(for: .locationUpdated)
+                            // Other recommender throttles checks to every 15 seconds, but
+                            // we want to know as soon as a relevant POI comes into range
+                            .throttle(for: 3.0, scheduler: RunLoop.main, latest: true)
+                            .receive(on: RunLoop.main)
+                            .sink(receiveValue: { [weak self] _ in
+                                guard let `self` = self else {
+                                    return
+                                }
+                                
+                                self.publishCurrentValue()
+                            }))
+    }
+    
+    deinit {
+        listeners.cancelAndRemoveAll()
+    }
+    
+    // MARK: Manage Publisher
+    
+    private func publishCurrentValue() {
+        var currentValue: (() -> AnyView)?
+        
+        defer {
+            // Publish the current value
+            self.publisher.value = currentValue
+        }
+        
+        guard let location = AppContext.shared.geolocationManager.location else {
+            // Location is unknown
+            return
+        }
+        
+        // Search for NaviLens-enabled POIs within 30 meters of given location
+        let navilensOnly = Filter.superCategories(orExpected: [SuperCategory.navilens])
+        let navilensInRangeDistance: CLLocationDistance = 30
+
+        guard let dataView = AppContext.shared.spatialDataContext.getDataView(for: location, searchDistance: navilensInRangeDistance) else {
+            return
+        }
+
+        guard let first = dataView.pois.filtered(by: navilensOnly).sorted(by: {
+            // Sort NaviLens-enabled POIs by distance
+            return location.distance(from: $0.centroidLocation) < location.distance(from: $1.centroidLocation)
+        }).first else {
+            // There are no NaviLens-enabled POIs nearby
+            return
+        }
+
+        if location.distance(from: first.centroidLocation) > navilensInRangeDistance {
+            // Nearest NaviLens-enabled POI is >30m away
+            return
+        }
+
+        GDLogAppInfo(String(format: "Nearest NaviLens POI is %fm away", location.distance(from: first.centroidLocation)))
+
+        // Update the current value
+        currentValue = {
+            AnyView(NavilensRecommenderView(poi: first))
+        }
+    }
+    
+}

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommenderView.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommenderView.swift
@@ -1,0 +1,39 @@
+//
+//  NavilensRecommenderView.swift
+//  Soundscape
+//
+//  Copyright (c) Soundscape Community.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+struct NavilensRecommenderView: View {
+    
+    // MARK: Properties
+    
+    @EnvironmentObject var navHelper: ViewNavigationHelper
+        
+    let poi: POI
+    
+    // MARK: Body
+    
+    var body: some View {
+        Button(action: launchNaviLens, label: {
+            RecommenderContainerView {
+                VStack(alignment: .leading, spacing: 4.0) {
+                    GDLocalizedTextView("navilens.title")
+                        .font(.body)
+
+                    Text(poi.localizedName)
+                        .font(.title3)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.clear)
+            .foregroundColor(Color.primaryForeground)
+            .accessibleTextFormat()
+        })
+    }
+    
+}

--- a/svcs/data/requirements.txt
+++ b/svcs/data/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.9.1
 aiopg==1.4.0
+Faker==37.1.0
 prometheus-client==0.21.1
 psycopg2-binary==2.9.9

--- a/svcs/data/utilities/random_tile_server.py
+++ b/svcs/data/utilities/random_tile_server.py
@@ -23,11 +23,13 @@ import math
 import random
 
 from aiohttp import web
+from faker import Faker
 
+fake = Faker()
 # Upper bound for fake OpenStreetMap node IDs
 MAX_OSM_ID = 1 << 40
 # Number of random features per tile (1/4 sq. mi.)
-FEATURE_DENSITY = 1000
+FEATURE_DENSITY = 200
 
 
 # This returns the NW-corner of the square. Use the function with xtile+1 and/or ytile+1 to get the other corners. With xtile+0.5 & ytile+0.5 it will return the center of the tile.
@@ -41,9 +43,8 @@ def num2deg(xtile, ytile, zoom):
 
 def random_feature(lat, lon, osm_id):
     # Create a mixture of normal and Navilens-enabled bus stops
-    properties = {"name": "Normal",}
+    properties = {}
     if random.choice([True, False]):
-        properties["name"] = "Navilens"
         properties["qr_code:navilens"] = "yes"
 
     # Return a bus stop at the given latitude + longitude
@@ -59,6 +60,7 @@ def random_feature(lat, lon, osm_id):
             "bus": "yes",
             "highway": "bus_stop",
             "public_transport": "platform",
+            "name": fake.street_name() + " " + fake.street_suffix(),
             **properties,
         },
         "type": "Feature",


### PR DESCRIPTION
Implements a `NavilensRecommender` class, which renders a button on the home screen to launch NaviLens when the user is within 30m of any NaviLens-tagged POI. This is closely based on the existing `RouteRecommender` which shows a suggested route on the home screen when the user is near an existing route's waypoint. 

A limitation of this approach is that the button is not shown if a route or beacon is active , since those controls use the same part of the home screen UI.