### PR TITLE
Incorporate feedback on NaviLens integration

### DIFF
--- a/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
@@ -817,6 +817,10 @@
 
 
 /*  */
+"beacon.suggest_navilens" = "Launch NaviLens for additional guidance.";
+
+
+/*  */
 "preview.title" = "Soundscape Street Preview";
 
 

--- a/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
@@ -1023,6 +1023,8 @@
 /*  */
 "location_detail.action.beacon" = "Start Audio Beacon";
 
+/*  */
+"location_detail.action.beacon_or_navilens" = "Start NaviLens or Audio Beacon";
 
 /*  */
 "location_detail.action.beacon.hint" = "Double tap to set an audio beacon at this location.";
@@ -4477,6 +4479,6 @@
 "whats_new.1_3_0.1.title" = "Testing in Texas";
 "whats_new.1_3_0.1.description" = "If you live in the Austin or San Antonio areas in Texas and would like to help us test a feature we are working on with NaviLens, please get in touch via the Send Feedback button from the main menu.";
 "location_detail.action.navilens.hint" = "Double tap to launch NaviLens.";
-"navilens.title" = "Launch NaviLens";
+"location_detail.action.beacon_or_navilens.hint" = "Double tap to launch NaviLens or set an audio beacon, based on how close this location is.";
 "troubleshooting.tile_server_url.explanation" = "This is the server from which Soundscape retrieves map data. You normally should not need to change this unless you are developing or testing Soundscape.";
 "troubleshooting.tile_server_url" = "Tile Server URL";

--- a/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
@@ -721,6 +721,9 @@
 /* Notification, Beacon location nearby. Audio beacon has been muted. */
 "beacon.beacon_location_within_audio_beacon_muted" = "Beacon within %@. Audio beacon has been muted.";
 
+/* Suggest the user launch NaviLens for the remaining distance. Appended to beacon.beacon_location_within_audio_beacon_muted. */
+"beacon.suggest_navilens" = "Launch NaviLens for additional guidance.";
+
 //------------------------------------------------------------------------------
 // MARK: - Preview
 //------------------------------------------------------------------------------

--- a/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
@@ -885,8 +885,14 @@
 /* Title for the action to set a beacon */
 "location_detail.action.beacon" = "Start Audio Beacon";
 
+/* Text label for the action to start audio beacon at a NaviLens-enabled location */
+"location_detail.action.beacon_or_navilens" = "Start NaviLens or Audio Beacon";
+
 /* Voiceover hint for the action to set a beacon */
 "location_detail.action.beacon.hint" = "Double tap to set an audio beacon at this location.";
+
+/* Voiceover hint for the action to set a beacon or launch NaviLens */
+"location_detail.action.beacon_or_navilens.hint" = "Double tap to launch NaviLens or set an audio beacon, based on how close this location is.";
 
 /* Text displayed when audio beacon action is disabled */
 "location_detail.action.beacon.hint.disabled" = "Setting a new audio beacon is disabled while route guidance is active.";
@@ -905,9 +911,6 @@
 
 /* Text displayed when street preview is disabled */
 "location_detail.action.preview.hint.disabled" = "Street Preview is disabled while route guidance is active.";
-
-/* Text label for the action to launch NaviLens */
-"navilens.title" = "Launch NaviLens";
 
 /* Voiceover hint for the action to launch NaviLens */
 "location_detail.action.navilens.hint" = "Double tap to launch NaviLens.";

--- a/apps/ios/GuideDogs/Assets/Localization/es-ES.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/es-ES.lproj/Localizable.strings
@@ -4444,7 +4444,6 @@
 "whats_new.1_3_0.1.description" = "Si vives en las áreas de Austin o San Antonio en Texas y deseas ayudarnos a probar una función en la que estamos trabajando con NaviLens, comuníquate con nosotros a través del botón Enviar comentarios del menú principal.";
 "whats_new.1_3_0.1.title" = "Prueba en Texas";
 "location_detail.action.navilens.hint" = "Pulsa dos veces para iniciar NaviLens.";
-"navilens.title" = "Iniciar NaviLens";
 "troubleshooting.tile_server_url" = "URL del servidor de teselas";
 "troubleshooting.tile_server_url.explanation" = "Este es el servidor desde el que Soundscape obtiene los datos de mapas. Normalmente no debes cambiar este a menos que estés desarrollando o probando Soundscape.";
 "route_detail.action.start_reversed_route.hint" = "Pulsa dos veces para iniciar esta ruta de regreso.";

--- a/apps/ios/GuideDogs/Assets/Localization/pt-BR.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/pt-BR.lproj/Localizable.strings
@@ -1051,10 +1051,6 @@
 
 
 /*  */
-"navilens.title" = "Iniciar NaviLens";
-
-
-/*  */
 "location_detail.action.directions.hint" = "Dê um toque duplo para abrir esta localização em um aplicativo de mapas externo";
 
 

--- a/apps/ios/GuideDogs/Assets/Localization/pt-PT.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/pt-PT.lproj/Localizable.strings
@@ -1049,9 +1049,6 @@
 /*  */
 "location_detail.action.preview.hint.disabled" = "O Street Preview está desativado enquanto a orientação de rotas está ativa";
 
-/*  */
-"navilens.title" = "Iniciar NaviLens";
-
 
 /*  */
 "location_detail.action.directions.hint" = "Faça duplo toque para abrir esta localização numa aplicação de mapas externa";

--- a/apps/ios/GuideDogs/Code/Behaviors/Default/Callouts/DestinationCallout.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Default/Callouts/DestinationCallout.swift
@@ -91,7 +91,12 @@ struct DestinationCallout: POICalloutProtocol {
             // Inform the user why the audio beacon has stopped
             if causedAudioDisabled {
                 let earcon = GlyphSound(.beaconFound)
-                let tts = TTSSound(GDLocalizedString("beacon.beacon_location_within_audio_beacon_muted", formattedDistance), at: markerLocation)
+                var text = GDLocalizedString("beacon.beacon_location_within_audio_beacon_muted", formattedDistance)
+                // Append suggestion to launch NaviLens if available at location
+                if (poi != nil) && LocationDetail(entity: poi!).source.hasNaviLens {
+                    text += " " + GDLocalizedString("beacon.suggest_navilens")
+                }
+                let tts = TTSSound(text, at: markerLocation)
                 
                 guard let layered = LayeredSound(earcon, tts) else {
                     return Sounds([earcon, tts])

--- a/apps/ios/GuideDogs/Code/Behaviors/Default/Callouts/POICallout.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Default/Callouts/POICallout.swift
@@ -171,8 +171,9 @@ struct POICallout: POICalloutProtocol {
             sounds.append(TTSSound(formattedName, at: soundLocation))
         }
         
-        // Announce "NaviLens available" for NaviLens-enabled locations
-        if poi.superCategory == "navilens" {
+        // Announce "NaviLens available" for NaviLens-enabled locations,
+        // unless NaviLens is already in the name
+        if poi.superCategory == "navilens" && !name.lowercased().contains("navilens") {
             sounds.append(TTSSound(GDLocalizedString("directions.navilens_available"), at: soundLocation))
         }
         

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Integrations.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Integrations.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Soundscape community. All rights reserved.
 //
 
-func launchNaviLens() {
+func launchNaviLens(detail: LocationDetail) {
     // Launch NaviLens app, or open App Store listing if not installed
     let navilensUrl = URL(string: "navilens://")!
     let appStoreUrl = URL(string: "https://apps.apple.com/us/app/navilens/id1273704914")!
@@ -14,5 +14,30 @@ func launchNaviLens() {
         UIApplication.shared.open(navilensUrl)
     } else {
         UIApplication.shared.open(appStoreUrl)
+    }
+}
+
+func guideToNaviLens(detail: LocationDetail) throws {
+    // Launch NaviLens if close enough, otherwise start beacon
+    guard let location = AppContext.shared.geolocationManager.location else {
+        // Location is unknown
+        return launchNaviLens(detail: detail)
+    }
+
+    // If our GPS is more precise than we are close, use a beacon
+    if location.distance(from: detail.location) > location.horizontalAccuracy {
+        try LocationActionHandler.beacon(locationDetail: detail)
+    } else {
+        launchNaviLens(detail: detail)
+    }
+}
+
+func safeGuideToNaviLens(poi: POI) {
+    // Launch NaviLens if starting a beacon throws an error
+    let detail = LocationDetail(entity: poi)
+    do {
+        try guideToNaviLens(detail: detail)
+    } catch {
+        launchNaviLens(detail: detail)
     }
 }

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Location/Location Action/LocationAction.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Location/Location Action/LocationAction.swift
@@ -31,18 +31,19 @@ enum LocationAction {
     }
     
     static func actions(for detail: LocationDetail) -> [LocationAction] {
-        var result: [LocationAction]
+        var result: [LocationAction] = [.beacon]
+        if detail.source.hasNaviLens {
+            // NaviLens action replaces beacon action
+            result = [.navilens]
+        }
         if detail.isMarker {
-            result = [.beacon, .edit, .preview, .share(isEnabled: true)]
+            result += [.edit, .preview, .share(isEnabled: true)]
         } else {
             // If the location does not have a backup coordinate
             // disable the save and share actions
             let isEnabled = detail.source.isCachingEnabled
             
-            result =  [.beacon, .save(isEnabled: isEnabled), .preview, .share(isEnabled: isEnabled)]
-        }
-        if detail.source.hasNaviLens {
-            result += [.navilens]
+            result +=  [.save(isEnabled: isEnabled), .preview, .share(isEnabled: isEnabled)]
         }
         return result
     }
@@ -75,7 +76,7 @@ enum LocationAction {
         case .beacon: return GDLocalizedString("location_detail.action.beacon")
         case .preview: return GDLocalizedString("preview.title")
         case .share: return GDLocalizedString("share.title")
-        case .navilens: return GDLocalizedString("navilens.title")
+        case .navilens: return GDLocalizedString("location_detail.action.beacon_or_navilens")
         }
     }
     
@@ -86,7 +87,7 @@ enum LocationAction {
         case .beacon: return isEnabled ? GDLocalizedString("location_detail.action.beacon.hint") : GDLocalizedString("location_detail.action.beacon.hint.disabled")
         case .preview: return isEnabled ? GDLocalizedString("location_detail.action.preview.hint") : GDLocalizedString("location_detail.action.preview.hint.disabled")
         case .share(let isEnabled): return isEnabled ? GDLocalizedString("location_detail.action.share.hint") : GDLocalizedString("location_detail.disabled.share")
-        case .navilens: return GDLocalizedString("location_detail.action.navilens.hint")
+        case .navilens: return GDLocalizedString("location_detail.action.beacon_or_navilens.hint")
         }
     }
     

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
@@ -688,7 +688,10 @@ extension HomeViewController: LocationActionDelegate {
                         self.present(firstUseAlert, animated: true, completion: nil)
                     }
                 case .navilens:
-                    launchNaviLens()
+                    // Set a beacon on the given location
+                    // and segue to the home view
+                    try guideToNaviLens(detail: detail)
+                    self.navigationController?.popToRootViewController(animated: true)
                 }
             } catch let error as LocationActionError {
                 let alert = LocationActionAlert.alert(for: error)

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/Location Detail/LocationDetailViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/Location Detail/LocationDetailViewController.swift
@@ -345,7 +345,19 @@ extension LocationDetailViewController: LocationActionDelegate {
                         self.present(firstUseAlert, animated: true, completion: nil)
                     }
                 case .navilens:
-                    launchNaviLens()
+                    // Set a beacon on the given location
+                    // and segue to the home view
+                    try guideToNaviLens(detail: detail)
+                    
+                    if let home = self.navigationController?.viewControllers.first as? HomeViewController {
+                        home.shouldFocusOnBeacon = true
+                    }
+                    
+                    if self.isPresentedModally && !self.isInPreviewController {
+                        self.dismiss(animated: true)
+                    } else {
+                        self.navigationController?.popToRootViewController(animated: true)
+                    }
                 }
             } catch let error as LocationActionError {
                 let alert = LocationActionAlert.alert(for: error)

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/NearbyTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/NearbyTableViewController.swift
@@ -376,7 +376,10 @@ extension NearbyTableViewController: LocationAccessibilityActionDelegate {
                         self.present(firstUseAlert, animated: true, completion: nil)
                     }
                 case .navilens:
-                    launchNaviLens()
+                    // Set a beacon on the given location
+                    // and segue to the home view
+                    try guideToNaviLens(detail: detail)
+                    self.navigationController?.popToRootViewController(animated: true)
                 }
                 
             } catch let error as LocationActionError {

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/SearchTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/SearchTableViewController.swift
@@ -348,7 +348,10 @@ extension SearchTableViewController: LocationActionDelegate {
                         self.present(firstUseAlert, animated: true, completion: nil)
                     }
                 case .navilens:
-                    launchNaviLens()
+                    // Set a beacon on the given location
+                    // and segue to the home view
+                    try guideToNaviLens(detail: detail)
+                    self.navigationController?.popToRootViewController(animated: true)
                 }
             } catch let error as LocationActionError {
                 let alert = LocationActionAlert.alert(for: error)

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Beacon/BeaconToolbarView.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Beacon/BeaconToolbarView.swift
@@ -135,7 +135,9 @@ struct BeaconToolbarView: View {
 
             // Launch NaviLens (applies to both beacon and route waypoint)
             if beacon.locationDetail.source.hasNaviLens {
-                Button(action: launchNaviLens, label: {
+                Button(action: {
+                        launchNaviLens(detail: beacon.locationDetail)
+                    }, label: {
                     Image("navilens")
                         .renderingMode(.template)
                         .resizable()
@@ -145,7 +147,7 @@ struct BeaconToolbarView: View {
 
                 })
                 .foregroundColor(.white)
-                .accessibilityLabel(GDLocalizedTextView("navilens.title"))
+                .accessibilityLabel(GDLocalizedTextView("location_detail.action.navilens.hint"))
             }
             
             Spacer()

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Markers & Routes/MarkersAndRoutesListNavigationHelper.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Markers & Routes/MarkersAndRoutesListNavigationHelper.swift
@@ -88,7 +88,10 @@ class MarkersAndRoutesListNavigationHelper: ViewNavigationHelper, LocationAccess
                     }
 
                 case .navilens:
-                    launchNaviLens()
+                    // Set a beacon on the given location
+                    // and segue to the home view
+                    try guideToNaviLens(detail: detail)
+                    self.popToRootViewController(animated: true)
                 }
             } catch let error as LocationActionError {
                 let alert = LocationActionAlert.alert(for: error)

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Containers/RecommenderContainerView.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Containers/RecommenderContainerView.swift
@@ -39,7 +39,7 @@ struct RecommenderContainerView<Content: View>: View {
         .padding(.horizontal, 18.0)
         .padding(.vertical, 12.0)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .linearGradientBackground(.purple)
+        .linearGradientBackground(.blue)
         .accessibilityElement(children: .combine)
     }
     

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommenderView.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommenderView.swift
@@ -19,10 +19,10 @@ struct NavilensRecommenderView: View {
     // MARK: Body
     
     var body: some View {
-        Button(action: launchNaviLens, label: {
+        Button(action: { safeGuideToNaviLens(poi: poi) }, label: {
             RecommenderContainerView {
                 VStack(alignment: .leading, spacing: 4.0) {
-                    GDLocalizedTextView("navilens.title")
+                    GDLocalizedTextView("location_detail.action.beacon_or_navilens")
                         .font(.body)
 
                     Text(poi.localizedName)


### PR DESCRIPTION
1. Adjust NaviLens recommender color
2. Skip appending NaviLens to callouts if already in POI/marker name
3. The home screen NaviLens suggestion now sets a beacon instead of launching NaviLens if the destination is further away than the current GPS accuracy. We similarly combine the start beacon and launch NaviLens actions on the location detail screen.
4. After announcing "beacon muted" when a beacon is reached, add speech suggesting launching NaviLens when available.