### PR TITLE
Cleanup: remove AppCenter dependency and telemetry setting.

### DIFF
--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -103,8 +103,6 @@
 		285C8B83230496D900E466DF /* GlyphCallout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285C8B82230496D900E466DF /* GlyphCallout.swift */; };
 		286145EB2625099F000E5525 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = 286145EA2625099F000E5525 /* SDWebImage */; };
 		2866A7C12625013400EBA2D8 /* DZNEmptyDataSet in Frameworks */ = {isa = PBXBuildFile; productRef = 2866A7C02625013400EBA2D8 /* DZNEmptyDataSet */; };
-		2866A7C72625020600EBA2D8 /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 2866A7C62625020600EBA2D8 /* AppCenterAnalytics */; };
-		2866A7C92625020600EBA2D8 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; productRef = 2866A7C82625020600EBA2D8 /* AppCenterCrashes */; };
 		2866A7CF2625028600EBA2D8 /* Reachability in Frameworks */ = {isa = PBXBuildFile; productRef = 2866A7CE2625028600EBA2D8 /* Reachability */; };
 		2866A7D5262502D500EBA2D8 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2866A7D4262502D500EBA2D8 /* CocoaLumberjackSwift */; };
 		286708D125005912002F962B /* street_non_1c.wav in Resources */ = {isa = PBXBuildFile; fileRef = 286708D025005912002F962B /* street_non_1c.wav */; };
@@ -1596,9 +1594,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				283B0307264B03920092F74F /* SDWebImageSwiftUI in Frameworks */,
-				2866A7C72625020600EBA2D8 /* AppCenterAnalytics in Frameworks */,
 				2866A7CF2625028600EBA2D8 /* Reachability in Frameworks */,
-				2866A7C92625020600EBA2D8 /* AppCenterCrashes in Frameworks */,
 				286F409D2624FF6000C3F80B /* NVActivityIndicatorView in Frameworks */,
 				2866A7D5262502D500EBA2D8 /* CocoaLumberjackSwift in Frameworks */,
 				91172A732AD8D56D00E6E8E9 /* CoreGPX in Frameworks */,
@@ -4505,8 +4501,6 @@
 			packageProductDependencies = (
 				286F409C2624FF6000C3F80B /* NVActivityIndicatorView */,
 				2866A7C02625013400EBA2D8 /* DZNEmptyDataSet */,
-				2866A7C62625020600EBA2D8 /* AppCenterAnalytics */,
-				2866A7C82625020600EBA2D8 /* AppCenterCrashes */,
 				2866A7CE2625028600EBA2D8 /* Reachability */,
 				2866A7D4262502D500EBA2D8 /* CocoaLumberjackSwift */,
 				28F1ECE1262505DC00E964C0 /* Realm */,
@@ -4585,7 +4579,6 @@
 			packageReferences = (
 				286F409B2624FF6000C3F80B /* XCRemoteSwiftPackageReference "NVActivityIndicatorView" */,
 				2866A7BF2625013400EBA2D8 /* XCRemoteSwiftPackageReference "DZNEmptyDataSet" */,
-				2866A7C52625020600EBA2D8 /* XCRemoteSwiftPackageReference "AppCenter-SDK-Apple" */,
 				2866A7CD2625028600EBA2D8 /* XCRemoteSwiftPackageReference "Reachability" */,
 				2866A7D3262502D500EBA2D8 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
 				28F1ECE0262505DC00E964C0 /* XCRemoteSwiftPackageReference "realm-cocoa" */,
@@ -5987,14 +5980,6 @@
 				revision = 9bffa69a83a9fa58a14b3cf43cb6dd8a63774179;
 			};
 		};
-		2866A7C52625020600EBA2D8 /* XCRemoteSwiftPackageReference "AppCenter-SDK-Apple" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Microsoft/AppCenter-SDK-Apple";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.4.3;
-			};
-		};
 		2866A7CD2625028600EBA2D8 /* XCRemoteSwiftPackageReference "Reachability" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ashleymills/Reachability.swift";
@@ -6057,16 +6042,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2866A7BF2625013400EBA2D8 /* XCRemoteSwiftPackageReference "DZNEmptyDataSet" */;
 			productName = DZNEmptyDataSet;
-		};
-		2866A7C62625020600EBA2D8 /* AppCenterAnalytics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2866A7C52625020600EBA2D8 /* XCRemoteSwiftPackageReference "AppCenter-SDK-Apple" */;
-			productName = AppCenterAnalytics;
-		};
-		2866A7C82625020600EBA2D8 /* AppCenterCrashes */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2866A7C52625020600EBA2D8 /* XCRemoteSwiftPackageReference "AppCenter-SDK-Apple" */;
-			productName = AppCenterCrashes;
 		};
 		2866A7CE2625028600EBA2D8 /* Reachability */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/apps/ios/GuideDogs/Code/App/BuildSettings.swift
+++ b/apps/ios/GuideDogs/Code/App/BuildSettings.swift
@@ -20,9 +20,9 @@ class BuildSettings {
     
     enum Source: String {
         case local
-        case appCenter
         case testFlight
         case appStore
+        case adhoc
     }
     
     // MARK: Properties
@@ -41,8 +41,6 @@ class BuildSettings {
         switch configuration {
         case .debug:
             return .local
-        case .adhoc:
-            return .appCenter
         case .release:
             // TestFlight builds contain an App Store receipt file named "sandboxReceipt"
             // Other sources have a receipt file named "receipt"
@@ -52,6 +50,8 @@ class BuildSettings {
             } else {
                 return .appStore
             }
+        case .adhoc:
+            return .adhoc
         }
     }
     

--- a/apps/ios/GuideDogs/Code/App/Logging/GDATelemetry.swift
+++ b/apps/ios/GuideDogs/Code/App/Logging/GDATelemetry.swift
@@ -5,9 +5,9 @@
 //  Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 //
+// This is just a stub, MS used AppCenter which is being depricated.
 
 import Foundation
-import AppCenterAnalytics
 
 public class GDATelemetry {
     
@@ -21,8 +21,7 @@ public class GDATelemetry {
         }
         set {
             SettingsContext.shared.telemetryOptout = !newValue
-            Analytics.enabled = newValue
-        }
+                    }
     }
     
     class func trackScreenView(_ screenName: String, with properties: [String: String]? = nil) {
@@ -48,8 +47,6 @@ public class GDATelemetry {
         if debugLog {
             print("[TEL] Event tracked: \(eventName)" + (propertiesToSend.isEmpty ? "" : " \(propertiesToSend)"))
         }
-        
-        Analytics.trackEvent(eventName, withProperties: propertiesToSend)
     }
     
 }

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Launch/DynamicLaunchViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Launch/DynamicLaunchViewController.swift
@@ -8,9 +8,6 @@
 
 import UIKit
 
-import AppCenter
-import AppCenterAnalytics
-import AppCenterCrashes
 import Combine
 
 class DynamicLaunchViewController: UIViewController {
@@ -43,11 +40,6 @@ class DynamicLaunchViewController: UIViewController {
             SpatialDataCache.useDefaultGeocoder()
         }
         
-        if !testEnvironment, !UIDeviceManager.isSimulator {
-            AppCenter.start(withAppSecret: "<#Secret#>", services: [Analytics.self, Crashes.self])
-            Analytics.enabled = !SettingsContext.shared.telemetryOptout
-            Crashes.enabled = !SettingsContext.shared.telemetryOptout
-        }
     }
     
     /// Notifies the view controller that its view was added to a view hierarchy.

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/SettingsViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/SettingsViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-import AppCenterAnalytics
 
 class SettingsViewController: BaseTableViewController {
     
@@ -19,7 +18,7 @@ class SettingsViewController: BaseTableViewController {
         case streetPreview = 3
         case troubleshooting = 4
         case about = 5
-        case telemetry = 6
+        // case telemetry = 6
     }
     
     private enum CalloutsRow: Int, CaseIterable {
@@ -49,7 +48,7 @@ class SettingsViewController: BaseTableViewController {
         IndexPath(row: 0, section: Section.streetPreview.rawValue): "streetPreview",
         IndexPath(row: 0, section: Section.troubleshooting.rawValue): "troubleshooting",
         IndexPath(row: 0, section: Section.about.rawValue): "about",
-        IndexPath(row: 0, section: Section.telemetry.rawValue): "telemetry"
+        // IndexPath(row: 0, section: Section.telemetry.rawValue): "telemetry"
     ]
     
     private static let collapsibleCalloutIndexPaths: [IndexPath] = [
@@ -89,7 +88,7 @@ class SettingsViewController: BaseTableViewController {
         case .streetPreview: return 1
         case .troubleshooting: return 1
         case .about: return 1
-        case .telemetry: return 1
+        // case .telemetry: return 1
         }
     }
     
@@ -117,11 +116,11 @@ class SettingsViewController: BaseTableViewController {
             
             return cell
             
-        case .telemetry:
-            let cell = tableView.dequeueReusableCell(withIdentifier: identifier ?? "default", for: indexPath) as! TelemetrySettingsTableViewCell
-            cell.parent = self
+        // case .telemetry:
+        //     let cell = tableView.dequeueReusableCell(withIdentifier: identifier ?? "default", for: indexPath) as! TelemetrySettingsTableViewCell
+        //     cell.parent = self
             
-            return cell
+        //     return cell
             
         case .audio:
             let cell = tableView.dequeueReusableCell(withIdentifier: identifier ?? "default", for: indexPath) as! MixAudioSettingCell
@@ -146,7 +145,7 @@ class SettingsViewController: BaseTableViewController {
         case .about: return GDLocalizedString("settings.section.about")
         case .streetPreview: return GDLocalizedString("preview.title")
         case .troubleshooting: return GDLocalizedString("settings.section.troubleshooting")
-        case .telemetry: return GDLocalizedString("settings.section.telemetry")
+        // case .telemetry: return GDLocalizedString("settings.section.telemetry")
         }
     }
     
@@ -156,7 +155,7 @@ class SettingsViewController: BaseTableViewController {
         switch sectionType {
         case .audio: return GDLocalizedString("settings.audio.mix_with_others.description")
         case .streetPreview: return GDLocalizedString("preview.include_unnamed_roads.subtitle")
-        case .telemetry: return GDLocalizedString("settings.section.telemetry.footer")
+        // case .telemetry: return GDLocalizedString("settings.section.telemetry.footer")
         default: return nil
         }
     }


### PR DESCRIPTION
Setting commented out with the view to re-adding telemetry with a different service in the future.