### PR TITLE
Clean up some compiler warnings

### DIFF
--- a/apps/ios/GuideDogs/Code/App/Feature Flags/Experiment Flighting/ExperimentManager.swift
+++ b/apps/ios/GuideDogs/Code/App/Feature Flags/Experiment Flighting/ExperimentManager.swift
@@ -14,6 +14,7 @@ enum KnownExperiment: CaseIterable {
     // Supports client experimentation
     // For each experiment, add a case to `KnownExperiment`
     //
+    case placeholder // TODO: Replace with real experiments
     
     var uuid: UUID {
         /*

--- a/apps/ios/GuideDogs/Code/App/Framework Extensions/Geo Extensions/CoreLocation+Extensions.swift
+++ b/apps/ios/GuideDogs/Code/App/Framework Extensions/Geo Extensions/CoreLocation+Extensions.swift
@@ -136,7 +136,7 @@ extension Array where Element == CLLocation {
 extension CLLocationCoordinate2D {
     
     var isValidLocationCoordinate: Bool {
-        return CLLocationCoordinate2DIsValid(self) && self != CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
+        return CLLocationCoordinate2DIsValid(self) && !self.isNear(to: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0))
     }
     
     func distance(from coordinate: CLLocationCoordinate2D) -> CLLocationDistance {
@@ -165,7 +165,7 @@ extension CLLocationCoordinate2D {
         }
         
         // Check if the coordinates are the same
-        guard self != coordinate else {
+        guard !self .isNear(to: coordinate )else {
             return 0
         }
         
@@ -221,13 +221,17 @@ extension CLLocationCoordinate2D {
     
 }
 
-extension CLLocationCoordinate2D: Equatable {
-    public static func == (lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
-        return lhs.equalTo(coordinate: rhs, threshold: 0.0000009)
+extension CLLocationCoordinate2D {
+    
+    public func isNear(to coordinate: CLLocationCoordinate2D, threshold: CLLocationDegrees = 0.0000009) -> Bool {
+        return fabs(self.latitude - coordinate.latitude) <= threshold && fabs(self.longitude - coordinate.longitude) <= threshold
     }
     
-    private func equalTo(coordinate: CLLocationCoordinate2D, threshold: CLLocationDegrees) -> Bool {
-        return fabs(self.latitude - coordinate.latitude) <= threshold && fabs(self.longitude - coordinate.longitude) <= threshold
+    public func isNear(to coordinate: CLLocationCoordinate2D?, threshold: CLLocationDegrees = 0.0000009) -> Bool {
+        guard let coordinate = coordinate else {
+            return false
+        }
+        return isNear(to: coordinate, threshold: threshold)
     }
 }
 

--- a/apps/ios/GuideDogs/Code/App/Framework Extensions/MapKit/MKMapView+Extensions.swift
+++ b/apps/ios/GuideDogs/Code/App/Framework Extensions/MapKit/MKMapView+Extensions.swift
@@ -20,7 +20,7 @@ extension MKMapView {
     }
     
     private func showAnnotationAndCenter(_ annotation: MKAnnotation) {
-        guard centerCoordinate != annotation.coordinate else {
+        guard !centerCoordinate.isNear(to: annotation.coordinate )else {
             // no-op
             return
         }

--- a/apps/ios/GuideDogs/Code/App/Helpers/GeometryUtils.swift
+++ b/apps/ios/GuideDogs/Code/App/Helpers/GeometryUtils.swift
@@ -70,7 +70,7 @@ class GeometryUtils {
         }
         
         // Check if we need to add a coordinate for a closed path
-        if coordinates.last! != coordinates.first! {
+        if !coordinates.last!.isNear(to: coordinates.first! ){
             (pixelX, pixelY) = VectorTile.getPixelXY(latitude: coordinates.first!.latitude, longitude: coordinates.first!.longitude, zoom: 16)
         }
         path.move(to: CGPoint(x: pixelX, y: pixelY))
@@ -125,7 +125,7 @@ class GeometryUtils {
     static func split(path: [CLLocationCoordinate2D],
                       atCoordinate coordinate: CLLocationCoordinate2D,
                       reversedDirection: Bool = false) -> [CLLocationCoordinate2D] {
-        guard let coordinateIndex = path.firstIndex(of: coordinate) else {
+        guard let coordinateIndex = path.firstIndex(where: {coordinate.isNear(to: $0)}) else {
             return []
         }
         
@@ -147,7 +147,8 @@ class GeometryUtils {
     static func rotate(circularPath path: [CLLocationCoordinate2D],
                        atCoordinate coordinate: CLLocationCoordinate2D,
                        reversedDirection: Bool = false) -> [CLLocationCoordinate2D] {
-        guard pathIsCircular(path), let coordinateIndex = path.firstIndex(of: coordinate) else {
+        guard pathIsCircular(path),
+              let coordinateIndex = path.firstIndex(where: {coordinate.isNear(to: $0)}) else {
             return []
         }
         
@@ -176,7 +177,7 @@ class GeometryUtils {
             return false
         }
         
-        return first == last
+        return first.isNear(to: last)
     }
     
     ///  Returns the distance of a coordinate path

--- a/apps/ios/GuideDogs/Code/Data/Authored Activities/AuthoredActivityContent.swift
+++ b/apps/ios/GuideDogs/Code/Data/Authored Activities/AuthoredActivityContent.swift
@@ -405,7 +405,7 @@ extension ActivityPOI: POI {
     }
     
     func contains(location: CLLocationCoordinate2D) -> Bool {
-        return coordinate == location
+        return coordinate.isNear(to: location)
     }
     
     func closestLocation(from location: CLLocation, useEntranceIfAvailable: Bool) -> CLLocation {

--- a/apps/ios/GuideDogs/Code/Data/Models/Cache Models/Intersection.swift
+++ b/apps/ios/GuideDogs/Code/Data/Models/Cache Models/Intersection.swift
@@ -380,7 +380,7 @@ class Intersection: Object, Locatable, Localizable {
             // Check roads that intersect with their vertices (first or last coordinates).
             // This represents the vertical section of the T.
             guard let roadCoordinates = road.coordinates else { return false }
-            guard intersectionCoordinate == roadCoordinates.first || intersectionCoordinate == roadCoordinates.last else { return false }
+            guard intersectionCoordinate.isNear(to: roadCoordinates.first) || intersectionCoordinate.isNear(to: roadCoordinates.last) else { return false }
             
             // Find a similar road that intersect with it's edge (not the first or last coordinates).
             // This represents the horizontal section of the T.
@@ -388,7 +388,7 @@ class Intersection: Object, Locatable, Localizable {
                 guard otherRoad.key != road.key && otherRoad.name == road.name else { return false }
                 guard let otherRoadCoordinates = otherRoad.coordinates else { return false }
                 
-                return intersectionCoordinate != otherRoadCoordinates.first && intersectionCoordinate != otherRoadCoordinates.last
+                return !intersectionCoordinate.isNear(to: otherRoadCoordinates.first) && !intersectionCoordinate.isNear(to: otherRoadCoordinates.last)
             }
         }
     }
@@ -520,7 +520,7 @@ extension Intersection {
             return intersection
         }
         
-        let similarIntersections = intersections.filter { $0.coordinate == intersection.coordinate }
+        let similarIntersections = intersections.filter { $0.coordinate.isNear(to: intersection.coordinate) }
         guard similarIntersections.count > 1 else {
             return intersection
         }
@@ -611,14 +611,14 @@ extension Intersection {
         let intersectionCoordinate = self.coordinate
         
         // 1. Road start
-        if intersectionCoordinate == roadCoordinates.first! {
+        if intersectionCoordinate.isNear(to: roadCoordinates.first) {
             guard let bearing = road.bearing() else { return nil }
             let direction = Direction(from: heading, to: bearing, type: .leftRight)
             
             return [RoadDirection(road, bearing, direction)]
         }
         // 2. Road end
-        else if intersectionCoordinate == roadCoordinates.last! {
+        else if intersectionCoordinate.isNear(to: roadCoordinates.last) {
             guard let bearing = road.bearing(reversedDirection: true) else { return nil }
             let direction = Direction(from: heading, to: bearing, type: .leftRight)
             
@@ -627,7 +627,7 @@ extension Intersection {
         // 3. Along the road
         else {
             // Find the intersection coordinate along the road
-            guard let intersectionCoordinateIndex = roadCoordinates.firstIndex(of: intersectionCoordinate) else {
+            guard let intersectionCoordinateIndex = roadCoordinates.firstIndex(where: {$0.isNear(to: intersectionCoordinate) }) else {
                 // We did not find a match for the intersection coordinate
                 // The road does not contain the intersection coordinate
                 DDLogDebug("Could not find an intersection coordinate for road: \(road.name)")

--- a/apps/ios/GuideDogs/Code/Data/Models/Database Models/ReferenceEntity.swift
+++ b/apps/ios/GuideDogs/Code/Data/Models/Database Models/ReferenceEntity.swift
@@ -406,7 +406,7 @@ class ReferenceEntity: Object, ObjectKeyIdentifiable {
     /// - Throws: If the database/cache cannot be accessed or the new reference entity cannot be added
     static func update(entity: ReferenceEntity, location: CLLocationCoordinate2D? = nil, nickname: String?, address: String?, annotation: String?, context: String? = nil, isTemp: Bool) throws {
         var locChanged: Bool = false
-        if let loc = location, loc != entity.coordinate {
+        if let loc = location, !loc.isNear(to: entity.coordinate) {
             locChanged = true
         }
         

--- a/apps/ios/GuideDogs/Code/Data/Models/Protocols/Road.swift
+++ b/apps/ios/GuideDogs/Code/Data/Models/Protocols/Road.swift
@@ -165,11 +165,11 @@ extension Road {
         guard let roadCoordinates = coordinates else { return .none }
         let intersectionCoordinate = intersection.coordinate
         
-        if intersectionCoordinate == roadCoordinates.first {
+        if intersectionCoordinate.isNear(to: roadCoordinates.first) {
             return .leading
-        } else if intersectionCoordinate == roadCoordinates.last {
+        } else if intersectionCoordinate.isNear(to: roadCoordinates.last) {
             return .trailing
-        } else if roadCoordinates.contains(intersectionCoordinate) {
+        } else if roadCoordinates.contains(where: {$0.isNear(to: intersectionCoordinate) }) {
             return .leadingAndTrailing
         }
         

--- a/apps/ios/GuideDogs/Code/Data/Models/Temp Models/GenericLocation.swift
+++ b/apps/ios/GuideDogs/Code/Data/Models/Temp Models/GenericLocation.swift
@@ -92,7 +92,7 @@ class GenericLocation: SelectablePOI {
     // MARK: Methods
 
     func contains(location: CLLocationCoordinate2D) -> Bool {
-        return location == self.location.coordinate
+        return location.isNear(to: self.location.coordinate)
     }
     
     func updateDistanceAndBearing(with location: CLLocation) {

--- a/apps/ios/GuideDogs/Code/Data/Preview/RoadAdjacentDataView.swift
+++ b/apps/ios/GuideDogs/Code/Data/Preview/RoadAdjacentDataView.swift
@@ -11,7 +11,7 @@ import CoreLocation
 import CocoaLumberjackSwift
 import CoreGPX
 
-struct RoadAdjacentDataView: AdjacentDataView, Equatable {
+struct RoadAdjacentDataView: AdjacentDataView /*, fixme Equatable  */ {
     
     typealias ReferenceEntityID = String
 
@@ -412,4 +412,38 @@ extension RoadAdjacentDataView {
         return updatedHistory
     }
     
+}
+
+// MARK: Equatable Conformance
+// this emulates the old custom Equatable conformance extension on CLLocationCoordinate2D, which was not based on exact equality.
+extension RoadAdjacentDataView: Equatable {
+    static func ==(lhs: RoadAdjacentDataView, rhs: RoadAdjacentDataView) -> Bool {
+        guard lhs.endpoint == rhs.endpoint,
+              lhs.direction == rhs.direction,
+              lhs.style    == rhs.style,
+              lhs.adjacent == rhs.adjacent,
+              lhs.coordinatesToEndpoint.count
+                == rhs.coordinatesToEndpoint.count,
+              lhs.adjacentCalloutLocationsHistory.count
+                == rhs.adjacentCalloutLocationsHistory.count
+        else {
+            return false
+        }
+        
+        // 2) compare the two coordinate arrays element-wise
+        for (c1, c2) in zip(lhs.coordinatesToEndpoint, rhs.coordinatesToEndpoint) {
+            if !c1.isNear(to: c2) { return false }
+        }
+        
+        // 3) compare the dictionary of callout locations
+        for (key, loc1) in lhs.adjacentCalloutLocationsHistory {
+            guard let loc2 = rhs.adjacentCalloutLocationsHistory[key],
+                  loc1.isNear(to: loc2)
+            else {
+                return false
+            }
+        }
+        
+        return true
+    }
 }

--- a/apps/ios/GuideDogs/Code/Data/Spatial Data/SpatialDataCache.swift
+++ b/apps/ios/GuideDogs/Code/Data/Spatial Data/SpatialDataCache.swift
@@ -346,7 +346,7 @@ class SpatialDataCache: NSObject {
     
     /// Returns all the intersections that connect to a given road
     static func intersection(forRoadKey roadKey: String, atCoordinate coordinate: CLLocationCoordinate2D) -> Intersection? {
-        return intersections(forRoadKey: roadKey)?.first(where: { $0.coordinate == coordinate })
+        return intersections(forRoadKey: roadKey)?.first(where: { $0.coordinate.isNear(to: coordinate) })
     }
     
     /// Returns all the intersections that connect to a given road, within a region.

--- a/apps/ios/GuideDogs/Code/Visual UI/Controls/Beacon/BeaconTitleViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Controls/Beacon/BeaconTitleViewController.swift
@@ -97,7 +97,7 @@ class BeaconTitleViewController: UIViewController {
             
             // If the selected location on the underlying entity has changed, reconfigure the view
             // to show the new distance
-            let beaconCoordinateDidChange = newValue?.locationDetail.location.coordinate != oldValue?.locationDetail.location.coordinate
+                                let beaconCoordinateDidChange = !(newValue?.locationDetail.location.coordinate.isNear(to: oldValue?.locationDetail.location.coordinate) ?? false)
             
             // If the underlying entity has changed, reconfigure the view and the view's accessibility
             // actions

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Location/Location Detail/LocationDetail.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Location/Location Detail/LocationDetail.swift
@@ -82,21 +82,21 @@ struct LocationDetail {
                     return false
                 }
                 
-                return lhsAt.coordinate == rhsAt.coordinate
-                
+                return lhsAt.coordinate.isNear(to: rhsAt.coordinate
+)
             case let .designData(lhsAt, lhsAddress):
                 guard case let .designData(rhsAt, rhsAddress) = rhs else {
                     return false
                 }
                 
-                return lhsAt.coordinate == rhsAt.coordinate && lhsAddress == rhsAddress
+                return lhsAt.coordinate.isNear(to: rhsAt.coordinate) && lhsAddress == rhsAddress
                 
             case let .screenshots(lhsPoi):
                 guard case let .screenshots(rhsPoi) = rhs else {
                     return false
                 }
                 
-                return lhsPoi.location.coordinate == rhsPoi.location.coordinate && lhsPoi.name == rhsPoi.name && lhsPoi.addressLine == rhsPoi.addressLine
+                return lhsPoi.location.coordinate.isNear(to: rhsPoi.location.coordinate) && lhsPoi.name == rhsPoi.name && lhsPoi.addressLine == rhsPoi.addressLine
             }
         }
         

--- a/apps/ios/GuideDogs/Code/Visual UI/Observable Data Stores/BeaconDetailStore.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Observable Data Stores/BeaconDetailStore.swift
@@ -176,7 +176,7 @@ class BeaconDetailStore: ObservableObject {
             
             let newValue = BeaconDetail.updateLocationDetailIfNeeded(for: oldValue)
             
-            guard newValue.locationDetail.source != oldValue.locationDetail.source || newValue.locationDetail.location.coordinate != oldValue.locationDetail.location.coordinate else {
+            guard newValue.locationDetail.source != oldValue.locationDetail.source || !newValue.locationDetail.location.coordinate.isNear(to: oldValue.locationDetail.location.coordinate) else {
                 return
             }
             

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/Location Detail/EditableMapViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/Location Detail/EditableMapViewController.swift
@@ -123,7 +123,7 @@ class EditableMapViewController: UIViewController {
             // Selected location is at the center of the map
             let newLocation = CLLocation(mapView.centerCoordinate)
             
-            if newLocation.coordinate != detail.centerLocation.coordinate {
+            if !newLocation.coordinate.isNear(to: detail.centerLocation.coordinate) {
                 // Notify the delegate
                 delegate?.viewController(self, didUpdateLocation: LocationDetail(detail, withUpdatedLocation: newLocation))
             }
@@ -132,7 +132,7 @@ class EditableMapViewController: UIViewController {
             dismiss(animated: true, completion: nil)
         } else {
             // `Edit` selected
-            if detail.centerLocation.coordinate == mapView.centerCoordinate {
+            if detail.centerLocation.coordinate.isNear(to: mapView.centerCoordinate) {
                 // Map region is centered at the given location
                 // Immediately configure the view
                 configureForEditLocation()

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/VoiceSettings.storyboard
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/VoiceSettings.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qVI-UV-Sh8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qVI-UV-Sh8">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,7 +13,7 @@
             <objects>
                 <tableViewController title="Voice" id="qVI-UV-Sh8" customClass="VoiceSettingsTableViewController" customModule="Soundscape" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" indicatorStyle="white" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ZVg-8B-oRT">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="668"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" name="Background Base"/>
                         <view key="tableHeaderView" contentMode="scaleToFill" id="SDc-sn-oTB">
@@ -22,7 +22,7 @@
                         </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="SpeakingRateCell" id="uZ5-LJ-IJn" customClass="SpeakingRateTableViewCell" customModule="Soundscape" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="49" width="375" height="43.333332061767578"/>
+                                <rect key="frame" x="0.0" y="55.333332061767578" width="375" height="43.333332061767578"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uZ5-LJ-IJn" id="rKf-ZO-TGv">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.333332061767578"/>
@@ -53,7 +53,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="VoiceInstructionsCell" textLabel="tfV-NW-qPT" rowHeight="120" style="IBUITableViewCellStyleDefault" id="47P-DS-YEw" userLabel="VoiceInstructionsCell" customClass="SpeakingRateTableViewCell" customModule="Soundscape" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="92.333332061767578" width="375" height="120"/>
+                                <rect key="frame" x="0.0" y="98.666664123535156" width="375" height="120"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="47P-DS-YEw" id="uFM-Vy-2MB">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
@@ -67,7 +67,7 @@
                                             <color key="textColor" name="Foreground 1"/>
                                             <nil key="highlightedColor"/>
                                             <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="localization" value="whats_new.3_2_0.2.description"/>
+                                                <userDefinedRuntimeAttribute type="string" keyPath="localization" value="voice.apple.additional"/>
                                             </userDefinedRuntimeAttributes>
                                         </label>
                                     </subviews>
@@ -76,21 +76,21 @@
                                 <color key="tintColor" name="Foreground 1"/>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="VoiceCell" textLabel="VVA-Iv-n9S" detailTextLabel="Jys-kc-y6t" style="IBUITableViewCellStyleSubtitle" id="zsK-EV-Xbb">
-                                <rect key="frame" x="0.0" y="212.33333206176758" width="375" height="49.666667938232422"/>
+                                <rect key="frame" x="0.0" y="218.66666412353516" width="375" height="56.666667938232422"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zsK-EV-Xbb" id="1mZ-N5-cAe">
-                                    <rect key="frame" x="0.0" y="0.0" width="338.33333333333331" height="49.666667938232422"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="335" height="56.666667938232422"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="VVA-Iv-n9S">
-                                            <rect key="frame" x="15.999999999999998" y="7.6666666666666643" width="28.333333333333332" height="17"/>
+                                            <rect key="frame" x="16" y="8.9999999999999982" width="33" height="20.333333333333332"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" name="Foreground 1"/>
                                             <color key="highlightedColor" name="Background 1"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="Jys-kc-y6t">
-                                            <rect key="frame" x="15.999999999999996" y="26.999999999999996" width="40.666666666666664" height="13.333333333333334"/>
+                                            <rect key="frame" x="15.999999999999996" y="32.333333333333329" width="43.666666666666664" height="14.333333333333334"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                             <color key="textColor" name="Foreground 2"/>
@@ -121,8 +121,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="hare" catalog="system" width="128" height="92"/>
-        <image name="tortoise" catalog="system" width="128" height="68"/>
+        <image name="hare" catalog="system" width="128" height="89"/>
+        <image name="tortoise" catalog="system" width="128" height="65"/>
         <namedColor name="Background 1">
             <color red="0.21600000560283661" green="0.29399999976158142" blue="0.46700000762939453" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>


### PR DESCRIPTION
* remove the CLLocationCoordinate2D extension that added Equatable Conformance and replace it with a .isNear(to:) method that behaves in exactly the same way but with a name that is more descriptive of its purpose
      This also avoids undefined behavior in the future if CLLocationCoordinate2D ever gains Equatable conformance.

      * fix localisation string in VoiceSettings.storyboard That had no affect on the app but was causing a warning

* add dummy experiment to git rid of warning about empty enum