### PR TITLE
If an exact locale match isn't found, fall back to using only the language part to cover cases where Soundscape supports the language but not the region. fixes #112

### DIFF
--- a/apps/ios/GuideDogs/Code/Language/Localization/LocalizationContext.swift
+++ b/apps/ios/GuideDogs/Code/Language/Localization/LocalizationContext.swift
@@ -160,6 +160,16 @@ class LocalizationContext {
                 break
             }
         }
+        // Fallback: match only on language part if no exact match found
+        if _firstSupportedLocale == nil {
+            for preferredLocale in Locale.preferredLocales {
+                if let languageCode = preferredLocale.languageCode,
+                   let locale = supportedLocales.first(where: { $0.languageCode == languageCode }) {
+                    _firstSupportedLocale = locale
+                    break
+                }
+            }
+        }
         
         return _firstSupportedLocale
     }


### PR DESCRIPTION
fixes #112