### PR TITLE
Refine search region parameters and manage MKLocalSearch instance in SearchResultsUpdater, fixes #215

### DIFF
--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -38,6 +38,7 @@ class SearchResultsUpdater: NSObject {
     private(set) var searchBarButtonClicked = false
     private var location: CLLocation?
     var context: Context = .partialSearchText
+    private var localSearch: MKLocalSearch?
     
     // MARK: Initialization
     
@@ -125,9 +126,9 @@ extension SearchResultsUpdater: UISearchResultsUpdating {
         let request = MKLocalSearch.Request()
         request.naturalLanguageQuery = searchText
         let coordinate = self.location!.coordinate
-        request.region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 75000, longitudinalMeters: 75000)
-        let search = MKLocalSearch(request: request)
-        search.start(completionHandler: searchWithTextCallback)
+        request.region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 1000, longitudinalMeters: 1000)
+        localSearch = MKLocalSearch(request: request)
+        localSearch!.start(completionHandler: searchWithTextCallback)
     }
 }
 
@@ -170,12 +171,13 @@ extension SearchResultsUpdater: UISearchBarDelegate {
         let request = MKLocalSearch.Request()
         request.naturalLanguageQuery = searchText
         let coordinate = self.location!.coordinate
-        request.region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 75000, longitudinalMeters: 75000)
-        let search = MKLocalSearch(request: request)
-        search.start(completionHandler: searchWithTextCallback)
+        request.region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 5000, longitudinalMeters: 5000)
+        localSearch = MKLocalSearch(request: request)
+        localSearch!.start(completionHandler: searchWithTextCallback)
     }
     
     private func searchWithTextCallback(using response: MKLocalSearch.Response?, error: Error?) -> Void {
+        localSearch = nil // finished with the MKLocalSearch instance
         guard error == nil else {
             return
         }


### PR DESCRIPTION
The MKLocalSearch instance was not stored, resulting in the search being canceled, resulting in very few if any search results. fixes Search Functionality Is Too Strict and Does Not Return Expected Results
Fixes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated search functionality with improved resource management and refined area coverage for search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->