### PR TITLE
Redundant language

### DIFF
--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Settings.storyboard
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Settings.storyboard
@@ -37,7 +37,7 @@
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <color key="highlightedColor" red="0.1333333333" green="0.25882352939999997" blue="0.40000000000000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="localization" value="settings.language.screen_title.2"/>
+                                                <userDefinedRuntimeAttribute type="string" keyPath="localization" value="settings.language.screen_title"/>
                                             </userDefinedRuntimeAttributes>
                                         </label>
                                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" image="globe" catalog="system" id="1L7-AG-6Os" customClass="TintedImageView" customModule="Soundscape" customModuleProvider="target">

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Settings.storyboard
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Settings.storyboard
@@ -1065,7 +1065,7 @@
                         </connections>
                     </tableView>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="localization" value="settings.language.screen_title.2"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="localization" value="settings.language.screen_title"/>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <outlet property="largeBannerContainerView" destination="OwD-aa-xRl" id="NFz-Lw-bk2"/>

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Settings.storyboard
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Settings.storyboard
@@ -1065,7 +1065,7 @@
                         </connections>
                     </tableView>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="localization" value="settings.language.screen_title"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="localization" value="settings.language.screen_title.2"/>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <outlet property="largeBannerContainerView" destination="OwD-aa-xRl" id="NFz-Lw-bk2"/>

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Settings.storyboard
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Settings.storyboard
@@ -37,7 +37,7 @@
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <color key="highlightedColor" red="0.1333333333" green="0.25882352939999997" blue="0.40000000000000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="localization" value="settings.language.screen_title"/>
+                                                <userDefinedRuntimeAttribute type="string" keyPath="localization" value="settings.language.screen_title.2"/>
                                             </userDefinedRuntimeAttributes>
                                         </label>
                                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" image="globe" catalog="system" id="1L7-AG-6Os" customClass="TintedImageView" customModule="Soundscape" customModuleProvider="target">


### PR DESCRIPTION
Changed the Language screen localization key from settings.language.screen_title to settings.language.screen_title.2.
This makes the top heading use “Language & Region” instead of the redundant “Language.”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the localized string for the Settings → Language screen title so the proper label displays to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->