### PR TITLE
[codex] Convert loading modal to UIKit

### DIFF
--- a/apps/ios/GuideDogs/Code/Visual UI/Controls/LoadingModalViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Controls/LoadingModalViewController.swift
@@ -3,30 +3,70 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
 class LoadingModalViewController: UIViewController {
     var loadingMessage: String = GDLocalizedString("general.loading.loading") {
         didSet {
-            guard let loadingMessageLabel = loadingMessageLabel else {
-                return
-            }
-            
             loadingMessageLabel.text = loadingMessage
             activityIndicatorView.accessibilityLabel = loadingMessage
         }
     }
-    
-    @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
-    @IBOutlet weak var loadingMessageLabel: UILabel!
-    
+
+    private let activityIndicatorView: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView(style: .large)
+        spinner.color = Colors.Foreground.primary
+        spinner.startAnimating()
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        return spinner
+    }()
+
+    private let loadingMessageLabel: UILabel = {
+        let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.font = UIFont.preferredFont(forTextStyle: .footnote)
+        label.isAccessibilityElement = false
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.textColor = Colors.Foreground.primary
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    init(loadingMessage: String = GDLocalizedString("general.loading.loading")) {
+        self.loadingMessage = loadingMessage
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("LoadingModalViewController must be created programmatically.")
+    }
+
+    override func loadView() {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "Background Shadow")
+        view.addSubview(activityIndicatorView)
+        view.addSubview(loadingMessageLabel)
+
+        NSLayoutConstraint.activate([
+            activityIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicatorView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            loadingMessageLabel.topAnchor.constraint(equalTo: activityIndicatorView.bottomAnchor),
+            loadingMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            loadingMessageLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            loadingMessageLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        self.view = view
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         loadingMessageLabel.text = loadingMessage
         activityIndicatorView.accessibilityLabel = loadingMessage
-        
-        loadingMessageLabel.isAccessibilityElement = false
     }
 }

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -418,8 +419,6 @@ class HomeViewController: UIViewController {
             vc.logContext = telemetryContext
         } else if let vc = segue.destination as? StandbyViewController {
             vc.delegate = self
-        } else if let vc = segue.destination as? LoadingModalViewController {
-            vc.loadingMessage = GDLocalizedString("general.loading.almost_ready")
         } else if let vc = segue.destination as? LocationDetailViewController {
             let locationDetail = sender as? LocationDetail
             vc.locationDetail = locationDetail

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Settings/StatusTableViewController.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -21,10 +22,6 @@ class StatusTableViewController: BaseTableViewController {
     
     private struct CellIdentifier {
         static let gps = "GPSStatus"
-    }
-    
-    private struct Segue {
-        static let showLoadingModal = "ShowLoadingModalSegue"
     }
     
     var reenableCalloutsAfterReload = false
@@ -54,14 +51,6 @@ class StatusTableViewController: BaseTableViewController {
         
         NotificationCenter.default.removeObserver(self, name: Notification.Name.spatialDataStateChanged, object: nil)
         NotificationCenter.default.removeObserver(self, name: Notification.Name.locationUpdated, object: AppContext.shared.spatialDataContext)
-    }
-    
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if let vc = segue.destination as? LoadingModalViewController {
-            vc.loadingMessage = GDLocalizedString("text.cleaning_things")
-            
-            NotificationCenter.default.addObserver(self, selector: #selector(spatialDataStateChanged(_:)), name: Notification.Name.spatialDataStateChanged, object: nil)
-        }
     }
     
     @objc
@@ -257,7 +246,7 @@ extension StatusTableViewController {
                 self.reenableCalloutsAfterReload = true
                 SettingsContext.shared.automaticCalloutsEnabled = false
             }    
-            self.performSegue(withIdentifier: Segue.showLoadingModal, sender: self)
+            self.presentLoadingModal()
             
             // Check that tiles can be downloaded before we attempt to delete the cache
             AppContext.shared.spatialDataContext.checkServiceConnection { [weak self] (success) in
@@ -305,7 +294,7 @@ extension StatusTableViewController {
                 self.reenableCalloutsAfterReload = true
                 SettingsContext.shared.automaticCalloutsEnabled = false
             }    
-            self.performSegue(withIdentifier: Segue.showLoadingModal, sender: self)
+            self.presentLoadingModal()
             
             // Check that tiles can be downloaded before we attempt to delete the cache
             AppContext.shared.spatialDataContext.checkServiceConnection { [weak self] (success) in
@@ -384,6 +373,19 @@ extension StatusTableViewController {
         GDLogSpatialDataWarn("Cached data deleted and addresses restored")
     }
     
+    private func presentLoadingModal() {
+        let viewController = LoadingModalViewController(loadingMessage: GDLocalizedString("text.cleaning_things"))
+        viewController.modalPresentationStyle = .overCurrentContext
+        viewController.modalTransitionStyle = .crossDissolve
+
+        present(viewController, animated: true)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(spatialDataStateChanged(_:)),
+                                               name: Notification.Name.spatialDataStateChanged,
+                                               object: nil)
+    }
+
     private func displayUnableToClearCacheWarning() {
         // Dismiss the loading screen
         dismiss(animated: true) { [weak self] in

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Devices.storyboard
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Devices.storyboard
@@ -231,56 +231,10 @@ Tap the button below to connect to a device.</string>
                         </userDefinedRuntimeAttributes>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" translucent="NO" prompted="NO"/>
-                    <connections>
-                        <segue destination="oX7-W4-RUK" kind="presentation" identifier="ShowLoadingModalSegue" modalPresentationStyle="overCurrentContext" modalTransitionStyle="crossDissolve" id="059-rI-b8n"/>
-                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="H0d-WB-u9x" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1988" y="166.99507389162562"/>
-        </scene>
-        <!--Loading Modal View Controller-->
-        <scene sceneID="RSY-n4-xM7">
-            <objects>
-                <viewController storyboardIdentifier="LoadingModal" id="oX7-W4-RUK" customClass="LoadingModalViewController" customModule="Soundscape" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="vKz-3g-vh1"/>
-                        <viewControllerLayoutGuide type="bottom" id="Bd6-l3-EC5"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="Hci-cE-v2d">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="ahF-iR-rOx">
-                                <rect key="frame" x="169" y="387.66666666666669" width="37" height="37"/>
-                                <color key="color" name="Foreground 1"/>
-                            </activityIndicatorView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading Message..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fPm-1h-yCu">
-                                <rect key="frame" x="0.0" y="424.66666666666674" width="375" height="387.33333333333326"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                <color key="textColor" name="Foreground 1"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <viewLayoutGuide key="safeArea" id="YSu-Dm-z6H"/>
-                        <color key="backgroundColor" name="Background Shadow"/>
-                        <constraints>
-                            <constraint firstItem="fPm-1h-yCu" firstAttribute="top" secondItem="ahF-iR-rOx" secondAttribute="bottom" id="1bj-iL-qbp"/>
-                            <constraint firstAttribute="trailing" secondItem="fPm-1h-yCu" secondAttribute="trailing" id="352-gu-Iaa"/>
-                            <constraint firstItem="fPm-1h-yCu" firstAttribute="leading" secondItem="Hci-cE-v2d" secondAttribute="leading" id="9N1-1y-75N"/>
-                            <constraint firstItem="YSu-Dm-z6H" firstAttribute="bottom" secondItem="fPm-1h-yCu" secondAttribute="bottom" id="AQj-Hv-akL"/>
-                            <constraint firstItem="ahF-iR-rOx" firstAttribute="centerX" secondItem="Hci-cE-v2d" secondAttribute="centerX" id="J4t-Te-qYA"/>
-                            <constraint firstItem="ahF-iR-rOx" firstAttribute="centerY" secondItem="Hci-cE-v2d" secondAttribute="centerY" id="gYf-jq-TOj"/>
-                        </constraints>
-                    </view>
-                    <connections>
-                        <outlet property="activityIndicatorView" destination="ahF-iR-rOx" id="22x-6B-YOP"/>
-                        <outlet property="loadingMessageLabel" destination="fPm-1h-yCu" id="CVg-uH-yYD"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="UQY-5B-vBI" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2820" y="166.99507389162562"/>
         </scene>
     </scenes>
     <resources>
@@ -293,9 +247,6 @@ Tap the button below to connect to a device.</string>
         </namedColor>
         <namedColor name="Background Base">
             <color red="0.097999997437000275" green="0.097999997437000275" blue="0.14900000393390656" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-        </namedColor>
-        <namedColor name="Background Shadow">
-            <color red="0.0" green="0.0" blue="0.0" alpha="0.75" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="Clear Color">
             <color red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
## Summary

- Convert `LoadingModalViewController` from storyboard-backed outlets to a programmatic UIKit view.
- Present the troubleshooting loading modal directly from `StatusTableViewController` instead of using `ShowLoadingModalSegue`.
- Remove the obsolete `LoadingModal` storyboard scene and its segue from `Devices.storyboard`.

## Impact

This removes one live leaf Interface Builder screen while preserving the existing over-current-context cross-dissolve loading modal behavior and accessibility label updates.

## Validation

- `apps/ios/Scripts/InterfaceBuilderAudit/main.swift --only candidates --kind all --format text`
- `xcodebuild build-for-testing -workspace GuideDogs.xcworkspace -scheme Soundscape -destination 'platform=iOS Simulator,id=7FBB0420-3968-4598-8DA4-B57D4B60A404' CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized the loading modal to a programmatic implementation; behavior and appearance remain consistent.
* **Bug Fix**
  * Settings now presents the loading modal directly during cache/user-data actions for more reliable presentation.
* **Cleanup**
  * Removed the storyboard-based loading modal scene and its old connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->