### PR TITLE
Add separate buttons for opening NaviLens and showing nearby Navilens codes to Navilens Recommender card

### DIFF
--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -529,6 +529,7 @@
 		62EACA2626697F2E00DBDECC /* LocationDetailAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EACA2526697F2E00DBDECC /* LocationDetailAnnotationView.swift */; };
 		62EACA2B26697F4300DBDECC /* WaypointDetailAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EACA2A26697F4300DBDECC /* WaypointDetailAnnotationView.swift */; };
 		6A4891BB2A5E66DE0002D146 /* ExternalNavigationApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4891BA2A5E66DE0002D146 /* ExternalNavigationApps.swift */; };
+		666CA3EAAA904E6EBFA10A53 /* NaviLensWakeOnForegroundTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EB7956C9AA4CB8A103128F /* NaviLensWakeOnForegroundTest.swift */; };
 		91172A732AD8D56D00E6E8E9 /* CoreGPX in Frameworks */ = {isa = PBXBuildFile; productRef = 91172A722AD8D56D00E6E8E9 /* CoreGPX */; };
 		914BAAF32AD745E400CB2171 /* DestinationManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914BAAF22AD745E400CB2171 /* DestinationManagerTest.swift */; };
 		914BAAFD2AD7483300CB2171 /* AudioEngineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914BAAFC2AD7483300CB2171 /* AudioEngineTest.swift */; };
@@ -1319,6 +1320,7 @@
 		62EACA2526697F2E00DBDECC /* LocationDetailAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetailAnnotationView.swift; sourceTree = "<group>"; };
 		62EACA2A26697F4300DBDECC /* WaypointDetailAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointDetailAnnotationView.swift; sourceTree = "<group>"; };
 		6A4891BA2A5E66DE0002D146 /* ExternalNavigationApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExternalNavigationApps.swift; path = Code/App/ExternalNavigationApps.swift; sourceTree = "<group>"; };
+		20EB7956C9AA4CB8A103128F /* NaviLensWakeOnForegroundTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaviLensWakeOnForegroundTest.swift; sourceTree = "<group>"; };
 		914BAAF22AD745E400CB2171 /* DestinationManagerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationManagerTest.swift; sourceTree = "<group>"; };
 		914BAAFC2AD7483300CB2171 /* AudioEngineTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioEngineTest.swift; sourceTree = "<group>"; };
 		914DEBCD2A3CE6B9007B161C /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3528,6 +3530,7 @@
 			isa = PBXGroup;
 			children = (
 				914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */,
+				20EB7956C9AA4CB8A103128F /* NaviLensWakeOnForegroundTest.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -4727,6 +4730,7 @@
 				AC3A3EE22C40C9080061EEB8 /* NearbyTableFilterTest.swift in Sources */,
 				91C82AAD2A5DCF040086D126 /*  GeolocationManagerTest.swift in Sources */,
 				91DC0CF92A46134600244CC8 /* GeometryUtilsTest.swift in Sources */,
+				666CA3EAAA904E6EBFA10A53 /* NaviLensWakeOnForegroundTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
@@ -715,6 +715,18 @@
 /* Button, Launch NaviLens */
 "beacon.action.navilens" = "Launch NaviLens";
 
+/* Button, Open NaviLens */
+"recommender.navilens.open" = "Open NaviLens";
+
+/* VoiceOver hint for the button to open NaviLens */
+"recommender.navilens.open.hint" = "Double tap to open NaviLens";
+
+/* Button, Show Nearby NaviLens Codes */
+"recommender.navilens.show_nearby" = "Show Nearby NaviLens Codes";
+
+/* VoiceOver hint for the button to show nearby NaviLens codes */
+"recommender.navilens.show_nearby.hint" = "Double tap to show nearby NaviLens codes";
+
 /* Notification, Double tap to unmute or mute the audio beacon */
 "beacon.action.mute_unmute_beacon.acc_hint" = "Double tap to mute or unmute the audio beacon";
 

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Integrations.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Integrations.swift
@@ -6,21 +6,89 @@
 //  Copyright © 2025 Soundscape community. All rights reserved.
 //
 
-func launchNaviLens(detail: LocationDetail) {
-    // Silence Soundscape before launching NaviLens
-    // Find the home screen in the view stack and trigger the sleep button
-    let rootVc = AppContext.rootViewController as? UINavigationController;
-    let homeVc = rootVc?.viewControllers.first as? HomeViewController;
-    homeVc?.onSleepTouchUpInside();
-    
+import UIKit
+
+final class NaviLensWakeOnForeground {
+    static let shared = NaviLensWakeOnForeground(notificationCenter: .default,
+                                                 appState: { AppContext.shared.state },
+                                                 sleep: { AppContext.shared.goToSleep() },
+                                                 wake: { AppContext.shared.wakeUp() })
+
+    private let notificationCenter: NotificationCenter
+    private let appState: () -> OperationState
+    private let sleep: () -> Void
+    private let wake: () -> Void
+    private var appDidBecomeActiveObserver: NSObjectProtocol?
+
+    init(notificationCenter: NotificationCenter,
+         appState: @escaping () -> OperationState,
+         sleep: @escaping () -> Void,
+         wake: @escaping () -> Void) {
+        self.notificationCenter = notificationCenter
+        self.appState = appState
+        self.sleep = sleep
+        self.wake = wake
+    }
+
+    func sleepUntilForeground() -> Bool {
+        guard appState() == .normal else {
+            return false
+        }
+
+        cancelPendingWake()
+
+        appDidBecomeActiveObserver = notificationCenter.addObserver(forName: Notification.Name.appDidBecomeActive,
+                                                                    object: nil,
+                                                                    queue: .main) { [weak self] _ in
+            self?.wakeUp()
+        }
+
+        sleep()
+        return true
+    }
+
+    func wakeUp() {
+        guard cancelPendingWake() else {
+            return
+        }
+
+        wake()
+    }
+
+    @discardableResult
+    private func cancelPendingWake() -> Bool {
+        guard let observer = appDidBecomeActiveObserver else {
+            return false
+        }
+
+        notificationCenter.removeObserver(observer)
+        appDidBecomeActiveObserver = nil
+        return true
+    }
+}
+
+func launchNaviLensApp() {
+    let wakeOnForeground = NaviLensWakeOnForeground.shared
+    let didScheduleWake = wakeOnForeground.sleepUntilForeground()
+
     // Launch NaviLens app, or open App Store listing if not installed
     let navilensUrl = URL(string: "navilens://")!
     let appStoreUrl = URL(string: "https://apps.apple.com/us/app/navilens/id1273704914")!
-    if UIApplication.shared.canOpenURL(navilensUrl) {
-        UIApplication.shared.open(navilensUrl)
-    } else {
-        UIApplication.shared.open(appStoreUrl)
+    let url = UIApplication.shared.canOpenURL(navilensUrl) ? navilensUrl : appStoreUrl
+
+    UIApplication.shared.open(url) { success in
+        guard !success else {
+            return
+        }
+
+        if didScheduleWake {
+            wakeOnForeground.wakeUp()
+        }
     }
+}
+
+func launchNaviLens(detail: LocationDetail) {
+    launchNaviLensApp()
 }
 
 func guideToNaviLens(detail: LocationDetail) throws {

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Integrations.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Integrations.swift
@@ -31,6 +31,8 @@ final class NaviLensWakeOnForeground {
     }
 
     func sleepUntilForeground() -> Bool {
+        assertMainThread()
+
         guard appState() == .normal else {
             return false
         }
@@ -48,6 +50,8 @@ final class NaviLensWakeOnForeground {
     }
 
     func wakeUp() {
+        assertMainThread()
+
         guard cancelPendingWake() else {
             return
         }
@@ -57,6 +61,8 @@ final class NaviLensWakeOnForeground {
 
     @discardableResult
     private func cancelPendingWake() -> Bool {
+        assertMainThread()
+
         guard let observer = appDidBecomeActiveObserver else {
             return false
         }
@@ -64,6 +70,10 @@ final class NaviLensWakeOnForeground {
         notificationCenter.removeObserver(observer)
         appDidBecomeActiveObserver = nil
         return true
+    }
+
+    private func assertMainThread() {
+        assert(Thread.isMainThread, "NaviLensWakeOnForeground must be used on the main thread")
     }
 }
 

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/POITable.storyboard
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/POITable.storyboard
@@ -331,7 +331,7 @@
         <!--Nearby Places-->
         <scene sceneID="iL5-Rj-LfD">
             <objects>
-                <tableViewController title="Nearby Places" id="eWR-kU-gGf" customClass="NearbyTableViewController" customModule="Soundscape" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="NearbyTableViewController" title="Nearby Places" id="eWR-kU-gGf" customClass="NearbyTableViewController" customModule="Soundscape" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" indicatorStyle="white" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="TN8-0o-Ade">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="208"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Containers/RecommenderContainerView.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Containers/RecommenderContainerView.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -12,11 +13,13 @@ struct RecommenderContainerView<Content: View>: View {
     
     // MARK: Properties
     
+    let combinesAccessibilityChildren: Bool
     let content: () -> Content
     
     // MARK: Initialization
     
-    init(@ViewBuilder content: @escaping () -> Content) {
+    init(combinesAccessibilityChildren: Bool = true, @ViewBuilder content: @escaping () -> Content) {
+        self.combinesAccessibilityChildren = combinesAccessibilityChildren
         self.content = content
     }
     
@@ -40,7 +43,7 @@ struct RecommenderContainerView<Content: View>: View {
         .padding(.vertical, 12.0)
         .frame(maxWidth: .infinity, alignment: .leading)
         .linearGradientBackground(.blue)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: combinesAccessibilityChildren ? .combine : .contain)
     }
     
 }

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommender.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommender.swift
@@ -62,9 +62,9 @@ class NavilensRecommender: Recommender {
             return
         }
         
-        // Search for NaviLens-enabled POIs within 30 meters of given location
+        // Search for NaviLens-enabled POIs within 100 meters of given location
         let navilensOnly = Filter.superCategories(orExpected: [SuperCategory.navilens])
-        let navilensInRangeDistance: CLLocationDistance = 30
+        let navilensInRangeDistance: CLLocationDistance = 100
 
         guard let dataView = AppContext.shared.spatialDataContext.getDataView(for: location, searchDistance: navilensInRangeDistance) else {
             return
@@ -79,7 +79,7 @@ class NavilensRecommender: Recommender {
         }
 
         if location.distance(from: first.centroidLocation) > navilensInRangeDistance {
-            // Nearest NaviLens-enabled POI is >30m away
+            // Nearest NaviLens-enabled POI is >100m away
             return
         }
 

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommenderView.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommenderView.swift
@@ -59,6 +59,8 @@ struct NavilensRecommenderView: View {
         let storyboard = UIStoryboard(name: "POITable", bundle: Bundle.main)
 
         guard let viewController = storyboard.instantiateViewController(identifier: "NearbyTableViewController") as? NearbyTableViewController else {
+            GDLogAppError("Failed to instantiate NearbyTableViewController from POITable storyboard")
+            assertionFailure("Failed to instantiate NearbyTableViewController from POITable storyboard")
             return
         }
 

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommenderView.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Recommender/Publishers/NaviLens/NavilensRecommenderView.swift
@@ -7,33 +7,98 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct NavilensRecommenderView: View {
-    
+
     // MARK: Properties
-    
+
     @EnvironmentObject var navHelper: ViewNavigationHelper
-        
+
     let poi: POI
-    
+
     // MARK: Body
-    
+
     var body: some View {
-        Button(action: { safeGuideToNaviLens(poi: poi) }, label: {
-            RecommenderContainerView {
+        RecommenderContainerView(combinesAccessibilityChildren: false) {
+            VStack(alignment: .leading, spacing: 12.0) {
                 VStack(alignment: .leading, spacing: 4.0) {
-                    GDLocalizedTextView("location_detail.action.beacon_or_navilens")
+                    GDLocalizedTextView("filter.navilens")
                         .font(.body)
 
                     Text(poi.localizedName)
                         .font(.title3)
                 }
+
+                VStack(spacing: 8.0) {
+                    Button(action: { launchNaviLensApp() }, label: {
+                        NavilensRecommenderActionLabel(image: Image("navilens"),
+                                                       titleKey: "recommender.navilens.open")
+                    })
+                    .buttonStyle(PlainButtonStyle())
+                    .accessibilityHint(GDLocalizedTextView("recommender.navilens.open.hint"))
+
+                    Button(action: { showNearbyNaviLensCodes() }, label: {
+                        NavilensRecommenderActionLabel(image: Image(systemName: "list.bullet"),
+                                                       titleKey: "recommender.navilens.show_nearby")
+                    })
+                    .buttonStyle(PlainButtonStyle())
+                    .accessibilityHint(GDLocalizedTextView("recommender.navilens.show_nearby.hint"))
+                }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.clear)
-            .foregroundColor(Color.primaryForeground)
-            .accessibleTextFormat()
-        })
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.clear)
+        .foregroundColor(Color.primaryForeground)
+        .accessibleTextFormat()
     }
-    
+
+    // MARK: Actions
+
+    private func showNearbyNaviLensCodes() {
+        let storyboard = UIStoryboard(name: "POITable", bundle: Bundle.main)
+
+        guard let viewController = storyboard.instantiateViewController(identifier: "NearbyTableViewController") as? NearbyTableViewController else {
+            return
+        }
+
+        viewController.context = NearbyDataContext()
+        viewController.currentFilter = NearbyTableFilter(type: .navilens)
+        viewController.navigationItem.title = GDLocalizedString("filter.navilens")
+
+        navHelper.pushViewController(viewController, animated: true)
+    }
+
+}
+
+private struct NavilensRecommenderActionLabel: View {
+
+    // MARK: Properties
+
+    let image: Image
+    let titleKey: String
+
+    // MARK: Body
+
+    var body: some View {
+        HStack(spacing: 8.0) {
+            image
+                .resizable()
+                .scaledToFit()
+                .frame(width: 24.0, height: 24.0)
+                .accessibilityHidden(true)
+
+            GDLocalizedTextView(titleKey)
+                .font(.body)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0.0)
+        }
+        .padding(.horizontal, 12.0)
+        .padding(.vertical, 10.0)
+        .frame(maxWidth: .infinity, minHeight: 44.0, alignment: .leading)
+        .background(Color.primaryForeground.opacity(0.18))
+        .cornerRadius(5.0)
+    }
+
 }

--- a/apps/ios/UnitTests/App/Helpers/NaviLensWakeOnForegroundTest.swift
+++ b/apps/ios/UnitTests/App/Helpers/NaviLensWakeOnForegroundTest.swift
@@ -1,0 +1,77 @@
+//
+//  NaviLensWakeOnForegroundTest.swift
+//  UnitTests
+//
+//  Copyright (c) Soundscape Community Contributors.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+@testable import Soundscape
+
+final class NaviLensWakeOnForegroundTest: XCTestCase {
+
+    func testSleepUntilForegroundSleepsAndWakesWhenAppBecomesActive() {
+        let notificationCenter = NotificationCenter()
+        let wakeExpectation = expectation(description: "Wake on foreground")
+        var state = OperationState.normal
+        var sleepCount = 0
+        var wakeCount = 0
+
+        let helper = NaviLensWakeOnForeground(notificationCenter: notificationCenter,
+                                              appState: { state },
+                                              sleep: {
+                                                  sleepCount += 1
+                                                  state = .sleep
+                                              },
+                                              wake: {
+                                                  wakeCount += 1
+                                                  state = .normal
+                                                  wakeExpectation.fulfill()
+                                              })
+
+        XCTAssertTrue(helper.sleepUntilForeground())
+        XCTAssertEqual(sleepCount, 1)
+        XCTAssertEqual(wakeCount, 0)
+        XCTAssertEqual(state, .sleep)
+
+        notificationCenter.post(name: Notification.Name.appDidBecomeActive, object: nil)
+
+        wait(for: [wakeExpectation], timeout: 1.0)
+        XCTAssertEqual(sleepCount, 1)
+        XCTAssertEqual(wakeCount, 1)
+        XCTAssertEqual(state, .normal)
+    }
+
+    func testSleepUntilForegroundDoesNothingWhenAlreadySleeping() {
+        let helper = NaviLensWakeOnForeground(notificationCenter: NotificationCenter(),
+                                              appState: { .sleep },
+                                              sleep: { XCTFail("Should not sleep again") },
+                                              wake: { XCTFail("Should not wake without a pending foreground wake") })
+
+        XCTAssertFalse(helper.sleepUntilForeground())
+        helper.wakeUp()
+    }
+
+    func testWakeUpAfterFailedLaunchWakesOnlyOnce() {
+        let notificationCenter = NotificationCenter()
+        var state = OperationState.normal
+        var wakeCount = 0
+
+        let helper = NaviLensWakeOnForeground(notificationCenter: notificationCenter,
+                                              appState: { state },
+                                              sleep: { state = .sleep },
+                                              wake: {
+                                                  wakeCount += 1
+                                                  state = .normal
+                                              })
+
+        XCTAssertTrue(helper.sleepUntilForeground())
+        helper.wakeUp()
+        notificationCenter.post(name: Notification.Name.appDidBecomeActive, object: nil)
+
+        XCTAssertEqual(wakeCount, 1)
+        XCTAssertEqual(state, .normal)
+    }
+
+}


### PR DESCRIPTION
## Summary
- add wake-on-foreground handling for the NaviLens recommender flow
- update integration routing and related storyboard/localization wiring
- add test coverage for NaviLens foreground wake behavior

## Validation
- Not run in this publish step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved NaviLens app integration with enhanced coordination when switching between apps
  * NaviLens recommendations now offer two actions: open the NaviLens app or browse nearby NaviLens codes

* **Accessibility**
  * Enhanced accessibility grouping configuration for the recommender interface

* **Tests**
  * Added unit tests for app foreground wake behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soundscape-community/soundscape/pull/263)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->