### PR TITLE
[codex] Update aiohttp security dependency

### DIFF
--- a/svcs/data/requirements.txt
+++ b/svcs/data/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.1
+aiohttp==3.13.4
 aiopg==1.4.0
 Faker==37.1.0
 prometheus-client==0.21.1


### PR DESCRIPTION
## Summary

Updates the data service `aiohttp` pin from `3.9.1` to `3.13.4` to pick up the patched version reported by Dependabot.

This targets the Python runtime dependency used by the tile server and related data-service utilities. Ruby/Fastlane dependency alerts are intentionally left out of scope because that tooling is dev-only and not used in CI.

## Validation

- `uv pip compile` resolves the updated direct Python pins for Linux/Python 3.9.
- Installed `aiohttp==3.13.4` with `uv` in a temporary Python 3.13 venv and imported `aiohttp.web.Application` successfully.

## Notes

Docker image builds were not run locally because `docker` is not installed in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated aiohttp dependency to version 3.13.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soundscape-community/soundscape/pull/265)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->