### PR TITLE
[codex] Fix navigation bar button contrast

### DIFF
--- a/apps/ios/GuideDogs/Code/App/Framework Extensions/UI Class Extensions/UIBarButtonItem+Extensions.swift
+++ b/apps/ios/GuideDogs/Code/App/Framework Extensions/UI Class Extensions/UIBarButtonItem+Extensions.swift
@@ -12,10 +12,17 @@ import UIKit
 extension UIBarButtonItem {
     
     static var defaultBackBarButtonItem: UIBarButtonItem {
-        UIBarButtonItem(title: GDLocalizedString("ui.back_button.title"), style: .plain, target: nil, action: nil)
+        let item = UIBarButtonItem(title: GDLocalizedString("ui.back_button.title"), style: .plain, target: nil, action: nil)
+        item.configureSoundscapeNavigationButton()
+        return item
     }
 
-    func configureSoundscapeNavigationButton() {
+    func configureSoundscapeNavigationButton(foregroundColor: UIColor? = nil) {
+        if let foregroundColor {
+            tintColor = foregroundColor
+            image = image?.withRenderingMode(.alwaysTemplate)
+        }
+
         if #available(iOS 26.0, *) {
             hidesSharedBackground = true
             sharesBackground = false

--- a/apps/ios/GuideDogs/Code/App/Framework Extensions/UI Class Extensions/UINavigationBar+Extentions.swift
+++ b/apps/ios/GuideDogs/Code/App/Framework Extensions/UI Class Extensions/UINavigationBar+Extentions.swift
@@ -19,52 +19,14 @@ extension UINavigationBar {
     }
     
     func configureAppearance(for style: Style) {
-        switch style {
-        case .default: configureDefaultAppearance()
-        case .transparentLightTitle: configureTransparentAppearance()
-        }
-    }
-    
-    private func configureDefaultAppearance() {
-        let color = Colors.Foreground.primary ?? UIColor.white
-        let buttonAppearance = UIBarButtonItemAppearance.soundscapeNavigationAppearance(foregroundColor: color)
-        
-        let appearance = UINavigationBarAppearance()
-        
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = Colors.Background.primary
-        appearance.titleTextAttributes = [.foregroundColor: color]
-        appearance.buttonAppearance = buttonAppearance
-        appearance.backButtonAppearance = buttonAppearance
-        appearance.doneButtonAppearance = buttonAppearance
-        appearance.configureSoundscapeBackIndicator(foregroundColor: color)
-        
+        let appearance = UINavigationBarAppearance.soundscapeAppearance(for: style)
+
+        tintColor = style.foregroundColor
+        barTintColor = style.backgroundColor
+        isTranslucent = style.isTranslucent
+        overrideUserInterfaceStyle = .dark
+
         apply(appearance)
-        
-        tintColor = color
-        barTintColor = Colors.Background.primary
-        isTranslucent = false
-    }
-    
-    private func configureTransparentAppearance() {
-        let color = Colors.Foreground.primary ?? UIColor.white
-        let buttonAppearance = UIBarButtonItemAppearance.soundscapeNavigationAppearance(foregroundColor: color)
-        
-        let appearance = UINavigationBarAppearance()
-        
-        appearance.configureWithTransparentBackground()
-        appearance.backgroundColor = .clear
-        appearance.titleTextAttributes = [.foregroundColor: color]
-        appearance.buttonAppearance = buttonAppearance
-        appearance.backButtonAppearance = buttonAppearance
-        appearance.doneButtonAppearance = buttonAppearance
-        appearance.configureSoundscapeBackIndicator(foregroundColor: color)
-        
-        apply(appearance)
-        
-        tintColor = color
-        barTintColor = .clear
-        isTranslucent = true
     }
 
     private func apply(_ appearance: UINavigationBarAppearance) {
@@ -77,16 +39,67 @@ extension UINavigationBar {
         // Set the back button
         items?.forEach {
             $0.backBarButtonItem = UIBarButtonItem.defaultBackBarButtonItem
-            $0.leftBarButtonItem?.configureSoundscapeNavigationButton()
-            $0.rightBarButtonItem?.configureSoundscapeNavigationButton()
-            $0.leftBarButtonItems?.forEach { $0.configureSoundscapeNavigationButton() }
-            $0.rightBarButtonItems?.forEach { $0.configureSoundscapeNavigationButton() }
+            $0.leftBarButtonItem?.configureSoundscapeNavigationButton(foregroundColor: tintColor)
+            $0.rightBarButtonItem?.configureSoundscapeNavigationButton(foregroundColor: tintColor)
+            $0.leftBarButtonItems?.forEach { $0.configureSoundscapeNavigationButton(foregroundColor: tintColor) }
+            $0.rightBarButtonItems?.forEach { $0.configureSoundscapeNavigationButton(foregroundColor: tintColor) }
         }
     }
     
 }
 
+extension UINavigationBar.Style {
+
+    var foregroundColor: UIColor {
+        Colors.Foreground.primary ?? .white
+    }
+
+    var backgroundColor: UIColor {
+        switch self {
+        case .default: return Colors.Background.primary ?? UIColor.Theme.darkBlue
+        case .transparentLightTitle: return .clear
+        }
+    }
+
+    var isTranslucent: Bool {
+        switch self {
+        case .default: return false
+        case .transparentLightTitle: return true
+        }
+    }
+
+    var usesTransparentBackground: Bool {
+        switch self {
+        case .default: return false
+        case .transparentLightTitle: return true
+        }
+    }
+
+}
+
 extension UINavigationBarAppearance {
+
+    static func soundscapeAppearance(for style: UINavigationBar.Style) -> UINavigationBarAppearance {
+        let appearance = UINavigationBarAppearance()
+        let foregroundColor = style.foregroundColor
+
+        if style.usesTransparentBackground {
+            appearance.configureWithTransparentBackground()
+        } else {
+            appearance.configureWithOpaqueBackground()
+        }
+
+        appearance.backgroundColor = style.backgroundColor
+        appearance.titleTextAttributes = [.foregroundColor: foregroundColor]
+
+        let buttonAppearance = UIBarButtonItemAppearance.soundscapeNavigationAppearance(foregroundColor: foregroundColor)
+        appearance.buttonAppearance = buttonAppearance
+        appearance.backButtonAppearance = buttonAppearance
+        appearance.doneButtonAppearance = buttonAppearance
+        appearance.configureSoundscapeBackIndicator(foregroundColor: foregroundColor)
+
+        return appearance
+    }
 
     func configureSoundscapeBackIndicator(foregroundColor: UIColor) {
         guard #available(iOS 26.0, *),

--- a/apps/ios/GuideDogs/Code/Visual UI/Modifiers/Navigation/NavigationBarStyle.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Modifiers/Navigation/NavigationBarStyle.swift
@@ -169,6 +169,14 @@ private extension UINavigationBar {
         tintColor = style.foregroundUIColor
         barTintColor = style.backgroundUIColor
         isTranslucent = style.isTranslucent
+        overrideUserInterfaceStyle = .dark
+
+        items?.forEach {
+            $0.leftBarButtonItem?.configureSoundscapeNavigationButton(foregroundColor: style.foregroundUIColor)
+            $0.rightBarButtonItem?.configureSoundscapeNavigationButton(foregroundColor: style.foregroundUIColor)
+            $0.leftBarButtonItems?.forEach { $0.configureSoundscapeNavigationButton(foregroundColor: style.foregroundUIColor) }
+            $0.rightBarButtonItems?.forEach { $0.configureSoundscapeNavigationButton(foregroundColor: style.foregroundUIColor) }
+        }
     }
     
 }

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
@@ -137,6 +137,7 @@ class HomeViewController: UIViewController {
         self.definesPresentationContext = true
         
         self.navigationItem.backBarButtonItem = UIBarButtonItem.defaultBackBarButtonItem
+        configureNavigationBarButtonContrast()
 
         configureCalloutButtonPanelView()
         
@@ -209,6 +210,7 @@ class HomeViewController: UIViewController {
         navigationController?.setNavigationBarHidden(false, animated: true)
         // Transparent navigation bar
         navigationController?.navigationBar.configureAppearance(for: .transparentLightTitle)
+        configureNavigationBarButtonContrast()
         
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleAppWillEnterForeground(_:)), name: Notification.Name.appWillEnterForeground, object: nil)
         
@@ -303,6 +305,13 @@ class HomeViewController: UIViewController {
             searchContainerHeightConstraint.constant = previousSearchContainerHeight
             NSLayoutConstraint.activate(cardContainerTopConstraints)
         }
+    }
+
+    private func configureNavigationBarButtonContrast() {
+        let foregroundColor = UINavigationBar.Style.transparentLightTitle.foregroundColor
+
+        navigationItem.leftBarButtonItem?.configureSoundscapeNavigationButton(foregroundColor: foregroundColor)
+        navigationItem.rightBarButtonItem?.configureSoundscapeNavigationButton(foregroundColor: foregroundColor)
     }
 
     private func configureCalloutButtonPanelView() {

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
@@ -312,6 +312,8 @@ class HomeViewController: UIViewController {
 
         navigationItem.leftBarButtonItem?.configureSoundscapeNavigationButton(foregroundColor: foregroundColor)
         navigationItem.rightBarButtonItem?.configureSoundscapeNavigationButton(foregroundColor: foregroundColor)
+        navigationItem.leftBarButtonItems?.forEach { $0.configureSoundscapeNavigationButton(foregroundColor: foregroundColor) }
+        navigationItem.rightBarButtonItems?.forEach { $0.configureSoundscapeNavigationButton(foregroundColor: foregroundColor) }
     }
 
     private func configureCalloutButtonPanelView() {

--- a/apps/ios/UnitTests/App/Helpers/NavigationControllerTest.swift
+++ b/apps/ios/UnitTests/App/Helpers/NavigationControllerTest.swift
@@ -46,4 +46,71 @@ class NavigationControllerTest: XCTestCase {
         XCTAssertNil(markerTutorialEditController.navigationItem.leftBarButtonItem)
     }
 
+    func testTransparentNavigationStyleTintsExistingImageButtons() {
+        let root = UIViewController()
+        let menuItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
+        let sleepItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
+        let navigationController = NavigationController(rootViewController: root)
+
+        root.navigationItem.leftBarButtonItem = menuItem
+        root.navigationItem.rightBarButtonItem = sleepItem
+
+        navigationController.navigationBar.configureAppearance(for: .transparentLightTitle)
+
+        XCTAssertEqual(navigationController.navigationBar.tintColor, UINavigationBar.Style.transparentLightTitle.foregroundColor)
+        XCTAssertEqual(menuItem.tintColor, UINavigationBar.Style.transparentLightTitle.foregroundColor)
+        XCTAssertEqual(sleepItem.tintColor, UINavigationBar.Style.transparentLightTitle.foregroundColor)
+        XCTAssertEqual(menuItem.image?.renderingMode, .alwaysTemplate)
+        XCTAssertEqual(sleepItem.image?.renderingMode, .alwaysTemplate)
+    }
+
+    func testDefaultNavigationStyleTintsExistingImageButtons() {
+        let root = UIViewController()
+        let menuItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
+        let sleepItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
+        let navigationController = NavigationController(rootViewController: root)
+
+        root.navigationItem.leftBarButtonItem = menuItem
+        root.navigationItem.rightBarButtonItem = sleepItem
+
+        navigationController.navigationBar.configureAppearance(for: .default)
+
+        XCTAssertEqual(navigationController.navigationBar.tintColor, UINavigationBar.Style.default.foregroundColor)
+        XCTAssertEqual(menuItem.tintColor, UINavigationBar.Style.default.foregroundColor)
+        XCTAssertEqual(sleepItem.tintColor, UINavigationBar.Style.default.foregroundColor)
+        XCTAssertEqual(menuItem.image?.renderingMode, .alwaysTemplate)
+        XCTAssertEqual(sleepItem.image?.renderingMode, .alwaysTemplate)
+    }
+
+    func testDefaultBackButtonDoesNotUseIOS26SharedBackground() throws {
+        let item = UIBarButtonItem.defaultBackBarButtonItem
+
+        if #available(iOS 26.0, *) {
+            XCTAssertTrue(item.hidesSharedBackground)
+            XCTAssertFalse(item.sharesBackground)
+        }
+    }
+
+    func testDefaultNavigationStyleKeepsLightBackButtonColor() {
+        let appearance = UINavigationBarAppearance.soundscapeAppearance(for: .default)
+        let foregroundColor = appearance.backButtonAppearance.normal.titleTextAttributes[.foregroundColor] as? UIColor
+
+        XCTAssertEqual(foregroundColor, UINavigationBar.Style.default.foregroundColor)
+    }
+
+    func testTransparentNavigationStyleKeepsLightBackButtonColor() {
+        let appearance = UINavigationBarAppearance.soundscapeAppearance(for: .transparentLightTitle)
+        let foregroundColor = appearance.backButtonAppearance.normal.titleTextAttributes[.foregroundColor] as? UIColor
+
+        XCTAssertEqual(foregroundColor, UINavigationBar.Style.transparentLightTitle.foregroundColor)
+    }
+
+    func testNavigationStyleForcesDarkInterfaceStyle() {
+        let navigationController = NavigationController(rootViewController: UIViewController())
+
+        navigationController.navigationBar.configureAppearance(for: .default)
+
+        XCTAssertEqual(navigationController.navigationBar.overrideUserInterfaceStyle, .dark)
+    }
+
 }


### PR DESCRIPTION
## Summary

- Applies the existing high-contrast navigation bar styling to navigation bar button items.
- Covers both singular button items and left/right button item arrays so grouped actions receive the same tint updates.
- Adds unit coverage for the navigation controller styling behavior.

## Impact

Navigation bar actions should remain legible when the app applies custom navigation bar appearances, including screens that configure multiple bar button items.

## Validation

- Not run in this session; branch already contained the implementation commits to publish.

## Notes

- The local working tree still has an uncommitted `apps/ios/GuideDogs.xcodeproj/project.pbxproj` version/project-ordering change. It was not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved contrast for navigation bar buttons with enhanced visual styling.

* **Tests**
  * Added comprehensive test coverage for navigation bar styling behavior and appearance configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soundscape-community/soundscape/pull/267)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->