### PR TITLE
[codex] Update What’s New entries

### DIFF
--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -525,8 +525,8 @@
 		62EACA2126697ED400DBDECC /* WaypointDetailAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EACA2026697ED400DBDECC /* WaypointDetailAnnotation.swift */; };
 		62EACA2626697F2E00DBDECC /* LocationDetailAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EACA2526697F2E00DBDECC /* LocationDetailAnnotationView.swift */; };
 		62EACA2B26697F4300DBDECC /* WaypointDetailAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EACA2A26697F4300DBDECC /* WaypointDetailAnnotationView.swift */; };
-		6A4891BB2A5E66DE0002D146 /* ExternalNavigationApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4891BA2A5E66DE0002D146 /* ExternalNavigationApps.swift */; };
 		666CA3EAAA904E6EBFA10A53 /* NaviLensWakeOnForegroundTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EB7956C9AA4CB8A103128F /* NaviLensWakeOnForegroundTest.swift */; };
+		6A4891BB2A5E66DE0002D146 /* ExternalNavigationApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4891BA2A5E66DE0002D146 /* ExternalNavigationApps.swift */; };
 		91172A732AD8D56D00E6E8E9 /* CoreGPX in Frameworks */ = {isa = PBXBuildFile; productRef = 91172A722AD8D56D00E6E8E9 /* CoreGPX */; };
 		914BAAF32AD745E400CB2171 /* DestinationManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914BAAF22AD745E400CB2171 /* DestinationManagerTest.swift */; };
 		914BAAFD2AD7483300CB2171 /* AudioEngineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914BAAFC2AD7483300CB2171 /* AudioEngineTest.swift */; };
@@ -773,6 +773,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		20EB7956C9AA4CB8A103128F /* NaviLensWakeOnForegroundTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaviLensWakeOnForegroundTest.swift; sourceTree = "<group>"; };
 		2809B80B2379E95B00F6C9AC /* calibration_success.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = calibration_success.wav; path = Assets/Sounds/calibration_success.wav; sourceTree = "<group>"; };
 		2809B80D2379E9A000F6C9AC /* connection_success.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = connection_success.wav; path = Assets/Sounds/connection_success.wav; sourceTree = "<group>"; };
 		2809B80F2379E9C700F6C9AC /* low_confidence.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = low_confidence.wav; path = Assets/Sounds/low_confidence.wav; sourceTree = "<group>"; };
@@ -1316,7 +1317,6 @@
 		62EACA2526697F2E00DBDECC /* LocationDetailAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetailAnnotationView.swift; sourceTree = "<group>"; };
 		62EACA2A26697F4300DBDECC /* WaypointDetailAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointDetailAnnotationView.swift; sourceTree = "<group>"; };
 		6A4891BA2A5E66DE0002D146 /* ExternalNavigationApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExternalNavigationApps.swift; path = Code/App/ExternalNavigationApps.swift; sourceTree = "<group>"; };
-		20EB7956C9AA4CB8A103128F /* NaviLensWakeOnForegroundTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaviLensWakeOnForegroundTest.swift; sourceTree = "<group>"; };
 		914BAAF22AD745E400CB2171 /* DestinationManagerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationManagerTest.swift; sourceTree = "<group>"; };
 		914BAAFC2AD7483300CB2171 /* AudioEngineTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioEngineTest.swift; sourceTree = "<group>"; };
 		914BAB002AD7490100CB2171 /* NavigationControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationControllerTest.swift; sourceTree = "<group>"; };
@@ -5486,7 +5486,7 @@
 				CODE_SIGN_ENTITLEMENTS = GuideDogs/Assets/PropertyLists/SoundscapeDF.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				ENABLE_BITCODE = NO;
@@ -5517,7 +5517,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/GuideDogs",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DADHOC";
 				PRODUCT_BUNDLE_IDENTIFIER = "services.soundscape-adhoc";
@@ -5778,7 +5778,7 @@
 				CODE_SIGN_ENTITLEMENTS = GuideDogs/Assets/PropertyLists/Soundscape.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 8;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = X4H33NKGKY;
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
@@ -5810,7 +5810,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/GuideDogs",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = "services.soundscape-debug";
@@ -5841,7 +5841,7 @@
 				CODE_SIGN_ENTITLEMENTS = GuideDogs/Assets/PropertyLists/Soundscape.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = X4H33NKGKY;
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				ENABLE_BITCODE = NO;
@@ -5871,7 +5871,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/GuideDogs",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = services.soundscape;

--- a/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
@@ -4484,7 +4484,7 @@
 "whats_new.1_3_0.1.title" = "Testing in Texas";
 "whats_new.1_3_0.1.description" = "If you live in the Austin or San Antonio areas in Texas and would like to help us test a feature we are working on with NaviLens, please get in touch via the \"Send Feedback\" button from the menu.";
 "whats_new.1_3_2.0.title" = "Improved NaviLens Integration";
-"whats_new.1_3_2.0.description" = "Soundscape now announces when there are NaviLens codes nearby. You can find NaviLens Codes in Nearby Places.";
+"whats_new.1_3_2.0.description" = "Soundscape now announces when there are NaviLens codes nearby. You can find NaviLens codes in Nearby Places.";
 "whats_new.1_3_2.1.title" = "Route Reversal";
 "whats_new.1_3_2.1.description" = "You can now reverse a route. This creates a new route with all the waypoints in the opposite order.";
 "whats_new.1_8_1.0.title" = "Language Updates";
@@ -4494,6 +4494,7 @@
 "whats_new.1_8_2.0.title" = "Adjust the Audio Beacon Angle in Settings";
 "whats_new.1_8_2.0.description" = "You can now adjust the angle of the beacon's ringing sound.";
 "whats_new.1_8_2.1.title" = "NaviLens Suggestions Now Offer Separate Actions to Open NaviLens or Show Nearby Codes";
+"whats_new.1_8_2.1.description" = "";
 "beacon.action.navilens" = "Launch NaviLens";
 "location_detail.action.beacon_or_navilens.hint" = "Double tap to launch NaviLens or set an audio beacon, based on how close this location is";
 "troubleshooting.tile_server_url.explanation" = "This is the server from which Soundscape retrieves map data. You normally should not need to change this unless you are developing or testing Soundscape.";

--- a/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
@@ -4483,6 +4483,17 @@
 "whats_new.1_3_0.0.description" = "Soundscape now supports head tracking with the Alto or Rondo versions of the Bose Frames. Once they're connected, your Bose Frames will tell Soundscape where you are facing, helping Soundscape to improve your audio experience. To connect your Bose Frames to Soundscape, go to the \"Head Tracking Headphones\" item in the Soundscape menu. We would love to hear your feedback about the Bose Frames support. You can contact us by choosing the \"Send Feedback\" option in the menu.";
 "whats_new.1_3_0.1.title" = "Testing in Texas";
 "whats_new.1_3_0.1.description" = "If you live in the Austin or San Antonio areas in Texas and would like to help us test a feature we are working on with NaviLens, please get in touch via the \"Send Feedback\" button from the menu.";
+"whats_new.1_3_2.0.title" = "Improved NaviLens Integration";
+"whats_new.1_3_2.0.description" = "Soundscape now announces when there are NaviLens codes nearby. You can find NaviLens Codes in Nearby Places.";
+"whats_new.1_3_2.1.title" = "Route Reversal";
+"whats_new.1_3_2.1.description" = "You can now reverse a route. This creates a new route with all the waypoints in the opposite order.";
+"whats_new.1_8_1.0.title" = "Language Updates";
+"whats_new.1_8_1.0.description" = "Added support for Persian/Farsi and Russian.";
+"whats_new.1_8_1.1.title" = "Bug Fixes";
+"whats_new.1_8_1.1.description" = "Fixed scrolling in markers and routes, and fixed an issue where search would not show all results.";
+"whats_new.1_8_2.0.title" = "Adjust the Audio Beacon Angle in Settings";
+"whats_new.1_8_2.0.description" = "You can now adjust the angle of the beacon's ringing sound.";
+"whats_new.1_8_2.1.title" = "NaviLens Suggestions Now Offer Separate Actions to Open NaviLens or Show Nearby Codes";
 "beacon.action.navilens" = "Launch NaviLens";
 "location_detail.action.beacon_or_navilens.hint" = "Double tap to launch NaviLens or set an audio beacon, based on how close this location is";
 "troubleshooting.tile_server_url.explanation" = "This is the server from which Soundscape retrieves map data. You normally should not need to change this unless you are developing or testing Soundscape.";

--- a/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
@@ -3541,6 +3541,39 @@
 /* Description of the request for testing in Texas */
 "whats_new.1_3_0.1.description" = "If you live in the Austin or San Antonio areas in Texas and would like to help us test a feature we are working on with NaviLens, please get in touch via the \"Send Feedback\" button from the menu.";
 
+/* Title for a What's New item about NaviLens improvements */
+"whats_new.1_3_2.0.title" = "Improved NaviLens Integration";
+
+/* Description for a What's New item about NaviLens improvements */
+"whats_new.1_3_2.0.description" = "Soundscape now announces when there are NaviLens codes nearby. You can find NaviLens Codes in Nearby Places.";
+
+/* Title for a What's New item about reversing routes */
+"whats_new.1_3_2.1.title" = "Route Reversal";
+
+/* Description for a What's New item about reversing routes */
+"whats_new.1_3_2.1.description" = "You can now reverse a route. This creates a new route with all the waypoints in the opposite order.";
+
+/* Title for a What's New item about added languages */
+"whats_new.1_8_1.0.title" = "Language Updates";
+
+/* Description for a What's New item about added languages */
+"whats_new.1_8_1.0.description" = "Added support for Persian/Farsi and Russian.";
+
+/* Title for a What's New item about bug fixes */
+"whats_new.1_8_1.1.title" = "Bug Fixes";
+
+/* Description for a What's New item about bug fixes */
+"whats_new.1_8_1.1.description" = "Fixed scrolling in markers and routes, and fixed an issue where search would not show all results.";
+
+/* Title for a What's New item about audio beacon angle settings */
+"whats_new.1_8_2.0.title" = "Adjust the Audio Beacon Angle in Settings";
+
+/* Description for a What's New item about audio beacon angle settings */
+"whats_new.1_8_2.0.description" = "You can now adjust the angle of the beacon's ringing sound.";
+
+/* Title for a What's New item about NaviLens suggestion actions */
+"whats_new.1_8_2.1.title" = "NaviLens Suggestions Now Offer Separate Actions to Open NaviLens or Show Nearby Codes";
+
 /* Description of how users can download new voices. "Settings" and "Spoken Content" should be translated in the same way they are translated in the iOS Settin gs app. {NumberedPlaceholder="iOS"} */
 "voice.apple.additional" = "Additional voices, including enhanced quality voices, can be downloaded in the Read & Speak section of the iOS accessibility settings.";
 

--- a/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
@@ -3545,7 +3545,7 @@
 "whats_new.1_3_2.0.title" = "Improved NaviLens Integration";
 
 /* Description for a What's New item about NaviLens improvements */
-"whats_new.1_3_2.0.description" = "Soundscape now announces when there are NaviLens codes nearby. You can find NaviLens Codes in Nearby Places.";
+"whats_new.1_3_2.0.description" = "Soundscape now announces when there are NaviLens codes nearby. You can find NaviLens codes in Nearby Places.";
 
 /* Title for a What's New item about reversing routes */
 "whats_new.1_3_2.1.title" = "Route Reversal";
@@ -3573,6 +3573,9 @@
 
 /* Title for a What's New item about NaviLens suggestion actions */
 "whats_new.1_8_2.1.title" = "NaviLens Suggestions Now Offer Separate Actions to Open NaviLens or Show Nearby Codes";
+
+/* Empty description for a What's New item that only needs a title */
+"whats_new.1_8_2.1.description" = "";
 
 /* Description of how users can download new voices. "Settings" and "Spoken Content" should be translated in the same way they are translated in the iOS Settin gs app. {NumberedPlaceholder="iOS"} */
 "voice.apple.additional" = "Additional voices, including enhanced quality voices, can be downloaded in the Read & Speak section of the iOS accessibility settings.";

--- a/apps/ios/GuideDogs/Assets/NewFeatures.json
+++ b/apps/ios/GuideDogs/Assets/NewFeatures.json
@@ -27,5 +27,41 @@
       "Title": "whats_new.1_3_0.1.title",
       "Description": "whats_new.1_3_0.1.description"
     }
-    ]
+  ],
+  "1.3.2": [
+    {
+      "Order": "0",
+      "Title": "whats_new.1_3_2.0.title",
+      "Description": "whats_new.1_3_2.0.description"
+    },
+    {
+      "Order": "1",
+      "Title": "whats_new.1_3_2.1.title",
+      "Description": "whats_new.1_3_2.1.description"
+    }
+  ],
+  "1.8.1": [
+    {
+      "Order": "0",
+      "Title": "whats_new.1_8_1.0.title",
+      "Description": "whats_new.1_8_1.0.description"
+    },
+    {
+      "Order": "1",
+      "Title": "whats_new.1_8_1.1.title",
+      "Description": "whats_new.1_8_1.1.description"
+    }
+  ],
+  "1.8.2": [
+    {
+      "Order": "0",
+      "Title": "whats_new.1_8_2.0.title",
+      "Description": "whats_new.1_8_2.0.description"
+    },
+    {
+      "Order": "1",
+      "Title": "whats_new.1_8_2.1.title",
+      "Description": ""
+    }
+  ]
 }

--- a/apps/ios/GuideDogs/Assets/NewFeatures.json
+++ b/apps/ios/GuideDogs/Assets/NewFeatures.json
@@ -61,7 +61,7 @@
     {
       "Order": "1",
       "Title": "whats_new.1_8_2.1.title",
-      "Description": ""
+      "Description": "whats_new.1_8_2.1.description"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds new What’s New entries from the edited draft for versions 1.3.2, 1.8.1, and the next 1.8.2 bucket.
- Adds matching English (US and GB) localized strings with spelling and grammar cleanup.
- Leaves `soundscape-whats-new-draft.md` out of the commit.

## Validation

- `jq . apps/ios/GuideDogs/Assets/NewFeatures.json >/dev/null`
- `plutil -lint apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "What's New" in-app release notes for versions 1.3.2, 1.8.1 and 1.8.2 describing NaviLens integration (nearby codes and separate actions), route reversal, Persian/Farsi & Russian language support, bug fixes, and audio beacon ring angle setting.
* **Chores**
  * Updated app build/marketing versioning to 1.8.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soundscape-community/soundscape/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->