### PR TITLE
Fix route waypoint beacon callout action

### DIFF
--- a/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidance.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidance.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -15,11 +16,11 @@ struct RouteProgress {
     let completed: Int
     let total: Int
     let isDone: Bool
-    
+
     var remaining: Int {
         return total - completed
     }
-    
+
     var percentComplete: Int {
         return (completed * 100 / total)
     }
@@ -31,26 +32,26 @@ extension Notification.Name {
 }
 
 class RouteGuidance: BehaviorBase {
-    
+
     struct PendingBeaconArgs {
         let id: UUID
         let waypoint: LocationDetail
         let enableAudio: Bool
     }
-    
+
     struct Key {
         static let isTransitioning = "isTransitioning"
     }
-    
+
     static let name = "RouteGuidance"
-    
+
     private unowned let spatialDataContext: SpatialDataProtocol
     private unowned let motionActivity: MotionActivityProtocol
-        
+
     var state: RouteGuidanceState
     private(set) var content: RouteDetail
     private(set) var nearestIntersectionKey: String?
-    
+
     /// If we are transitioning to a waypoint but have not yet arrived, this contains information about the upcoming waypoint beacon. We do this transition instead of just changing if `isArrivingAtWaypoint` is `true`.
     /// see: `setOrTransitionBeacon(to waypoint:, enableAudio:, skipAsyncFinish:)`
     private var pendingBeaconArgs: PendingBeaconArgs?
@@ -64,48 +65,48 @@ class RouteGuidance: BehaviorBase {
     private var beaconObserver: AnyCancellable?
     /// Unless `shouldResume = true`, the route's state will be reset each time the route is activated
     var shouldResume = false
-    
+
     private var lastSaveTime: Date?
     var runningTime: TimeInterval {
         guard !state.isFinal else {
             return state.totalTime
         }
-        
+
         guard let lastSaveTime = lastSaveTime else {
             return state.totalTime
         }
-        
+
         return state.totalTime + Date().timeIntervalSince(lastSaveTime)
     }
-    
+
     var progress: RouteProgress {
         return RouteProgress(currentWaypoint: currentWaypoint, completed: state.visited.count, total: content.waypoints.count, isDone: arrivedAtFinalWaypoint)
     }
-    
+
     var currentWaypoint: (index: Int, waypoint: LocationDetail)? {
         guard let index = state.waypointIndex, index >= 0, index < content.waypoints.count else {
             return nil
         }
-        
+
         return (index: index, waypoint: content.waypoints[index])
     }
-    
+
     var isAdaptiveSportsEvent: Bool {
         if case .trailActivity = content.source {
             return true
         }
-        
+
         return false
     }
-    
+
     private var isBeaconAsync: Bool {
         return AppContext.shared.spatialDataContext.destinationManager.isCurrentBeaconAsyncFinishable
     }
-    
+
     private var isBeaconAudioEnabled: Bool {
         return AppContext.shared.spatialDataContext.destinationManager.isAudioEnabled
     }
-    
+
     lazy var telemetryContext: String = {
         switch content.source {
         case .database, .cache:
@@ -114,27 +115,27 @@ class RouteGuidance: BehaviorBase {
             return "asevent"
         }
     }()
-    
+
     init(_ detail: RouteDetail, spatialData: SpatialDataProtocol, motion: MotionActivityProtocol) {
         self.content = detail
         self.state = RouteGuidanceState.load(id: detail.id) ?? RouteGuidanceState(id: detail.id)
         self.spatialDataContext = spatialData
         self.motionActivity = motion
-        
+
         super.init(blockedAutoGenerators: [BeaconCalloutGenerator.self], blockedManualGenerators: [BeaconCalloutGenerator.self])
     }
-    
+
     convenience init(_ content: AuthoredActivityContent, spatialData: SpatialDataProtocol, motion: MotionActivityProtocol) {
         let detail = RouteDetail(source: .trailActivity(content: content))
         self.init(detail, spatialData: spatialData, motion: motion)
     }
-    
+
     override func activate(with parent: Behavior?) {
         let gen = RouteGuidanceGenerator(self, motionActivity: motionActivity, alreadyCompleted: progress.isDone)
-        
+
         manualGenerators.append(gen)
         autoGenerators.append(gen)
-        
+
         if case .database(let id) = content.source {
             do {
                 try Route.updateLastSelectedDate(id: id)
@@ -142,7 +143,7 @@ class RouteGuidance: BehaviorBase {
                 GDLogError(.routeGuidance, "Failed to update last selected date")
             }
         }
-        
+
         if shouldResume {
             // Do not reset the route state
             // Reset `shouldResume`
@@ -153,7 +154,7 @@ class RouteGuidance: BehaviorBase {
             state.isFinal = false
             state.waypointIndex = 0
             state.visited = []
-            
+
             do {
                 try state.save(id: content.id)
                 NotificationCenter.default.post(name: Notification.Name.routeGuidanceStateChanged, object: self)
@@ -161,17 +162,17 @@ class RouteGuidance: BehaviorBase {
                 GDLogError(.routeGuidance, "Unable to save Route Guidance state!")
             }
         }
-        
+
         // Make sure the initial waypoint is set (either it is already set from a loaded state file, or we set it to zero
         if state.waypointIndex == nil {
             state.waypointIndex = 0
         }
-        
+
         // For the time being, always set the beacon immediately
         guard let current = currentWaypoint else {
             return
         }
-        
+
         // Make sure there isn't an existing beacon when we start the first route beacon
         if AppContext.shared.spatialDataContext.destinationManager.isDestinationSet {
             do {
@@ -180,35 +181,35 @@ class RouteGuidance: BehaviorBase {
                 GDLogError(.routeGuidance, "Unable to stop the existing beacon!")
             }
         }
-        
+
         nearestIntersectionKey = findNearestIntersection()
-        
+
         setOrTransitionBeacon(to: current.waypoint)
         saveState()
         lastSaveTime = Date()
-        
+
         beaconObserver = NotificationCenter.default.publisher(for: Notification.Name.dynamicPlayerFinished).receive(on: RunLoop.main).sink { notification in
             guard !self.isFinished else {
                 return
             }
-            
+
             // and there is a pending beacon...
             guard let args = self.pendingBeaconArgs else {
                 if self.progress.isDone {
                     self.isFinished = true
-                    
+
                     // Play the final arrival callouts
                     self.delegate?.process(WaypointArrivalEvent(self.progress))
                 }
-                
+
                 return
             }
-            
+
             // When the beacon has been removed...
             guard notification.userInfo?[AudioEngine.Keys.playerId] as? UUID == args.id else {
                 return
             }
-            
+
             if self.isArrivingAtWaypoint {
                 // Play the arrival callouts and then finish setting the new beacon
                 self.delegate?.process(WaypointArrivalEvent(self.progress))
@@ -217,66 +218,66 @@ class RouteGuidance: BehaviorBase {
                 self.finishTransitioningBeacon()
             }
         }
-        
+
         super.activate(with: parent)
         GDATelemetry.track("routeguidance.started", with: ["context": telemetryContext])
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(3)) {
             guard let location = AppContext.shared.geolocationManager.location else {
                 return
             }
-            
+
             self.delegate?.process(RouteGuidanceReadyEvent())
             self.delegate?.process(BeginWaypointDistanceCalloutsEvent(user: location, waypoint: current.waypoint.location))
         }
     }
-    
+
     override func deactivate() -> Behavior? {
         // When the route ends, display the `RouteCompleteView`
         let context = RouteCompleteViewRepresentable(route: self)
-        
+
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .presentAnyModalViewController, object: self, userInfo: [AnyModalViewObserver.Keys.context: context])
         }
-        
+
         beaconObserver?.cancel()
         beaconObserver = nil
-        
+
         nearestIntersectionKey = nil
-        
+
         saveState()
         clearBeacon()
         updateNowPlayingInfo(nil)
-        
+
         GDATelemetry.track("routeguidance.stopped", with: ["context": telemetryContext, "completed": String(state.isFinal)])
-            
+
         return super.deactivate()
     }
-    
+
     override func sleep() {
         super.sleep()
-        
+
         let manager = AppContext.shared.spatialDataContext.destinationManager
-        
+
         // Ensure the beacon audio turns off when the app enters sleep mode
         if manager.isAudioEnabled {
             manager.toggleDestinationAudio(forceMelody: false)
         }
-        
+
         saveState()
     }
-    
+
     override func wake() {
         // Reset the last save time so that we don't track all the time the app was asleep
         lastSaveTime = Date()
-        
+
         super.wake()
-        
+
         // Ensure the beacon audio turns on when the app wakes up
         let manager = AppContext.shared.spatialDataContext.destinationManager
         manager.toggleDestinationAudio(forceMelody: true)
     }
-    
+
     /// Adds the index of the current waypoint to the visited waypoints and then switches to
     /// the next waypoint.
     ///
@@ -285,22 +286,22 @@ class RouteGuidance: BehaviorBase {
         guard let index = state.waypointIndex else {
             return false
         }
-        
+
         // If this waypoint was already completed, then just move onto the next one
         guard !state.visited.contains(index) else {
             GDATelemetry.track("routeguidance.waypoint_revisited", with: ["context": telemetryContext])
             nextWaypoint(automatic: true)
             return true
         }
-        
+
         state.visited.append(index)
         GDATelemetry.track("routeguidance.waypoint_visited", with: ["context": telemetryContext])
-        
+
         // If the route is complete, turn off the audio beacon. The beacon will still be set on the last waypoint, but the
         // audio will be disabled. The user can turn it on if they wish.
         guard index != content.waypoints.count - 1 else {
             arrivedAtFinalWaypoint = true
-            
+
             if isBeaconAsync && isBeaconAudioEnabled {
                 // Toggle off the beacon's audio. As soon as it finishes playing the ending melody,
                 // we will trigger the arrival callouts
@@ -309,40 +310,54 @@ class RouteGuidance: BehaviorBase {
                 if !isBeaconAsync && isBeaconAudioEnabled {
                     AppContext.shared.spatialDataContext.destinationManager.toggleDestinationAudio(false, forceMelody: true)
                 }
-                
+
                 // If the beacon is already muted, then we should go ahead and play the arrival callouts
                 // without waiting for the beacon to stop
                 isFinished = true
                 let event = WaypointArrivalEvent(self.progress)
-                
+
                 DispatchQueue.main.async {
                     self.delegate?.process(event)
                 }
             }
-            
+
             nearestIntersectionKey = nil
             saveState(finalize: true)
             GDATelemetry.track("routeguidance.completed", with: ["context": telemetryContext])
             return true
         }
-        
+
         // Update to the next waypoint and save the route guidance state
         nextWaypoint(automatic: true)
         return true
     }
-    
+
     func finishTransitioningBeacon() {
         // and there is a pending beacon...
         guard let args = self.pendingBeaconArgs else {
             return
         }
-        
+
         // start the pending beacon
         self.pendingBeaconArgs = nil
         self.completeSetBeacon(waypoint: args.waypoint, enableAudio: args.enableAudio)
         self.delegate?.process(WaypointDepartureEvent(progress))
     }
-    
+
+    @discardableResult
+    func callOutCurrentWaypoint() -> Bool {
+        guard currentWaypoint != nil else {
+            return false
+        }
+
+        guard let delegate = delegate else {
+            return false
+        }
+
+        delegate.process(RouteWaypointCalloutEvent())
+        return true
+    }
+
     /// Updates the `waypointIndex` property of the state object to be the index of the
     /// next waypoint and then saves the route guidance's state.
     /// - Parameter automatic: If `false`, we play departure callouts immediately instead of queueing.
@@ -355,31 +370,31 @@ class RouteGuidance: BehaviorBase {
             // If the waypointIndex is currently nil, then default to 0
             state.waypointIndex = 0
         }
-        
+
         // If the user manually tapped the "Next" button, then hush and current callouts so the
         // departure callouts happen immediately and don't queue
         if !automatic {
             delegate?.interruptCurrent(clearQueue: true, playHush: false)
         }
-        
+
         if let current = currentWaypoint {
             updateNowPlayingInfo(current)
             isArrivingAtWaypoint = automatic
             setOrTransitionBeacon(to: current.waypoint, skipAsyncFinish: !automatic)
-            
+
             GDLogInfo(.routeGuidance, "Route Guidance: Current waypoint is #\(current.index)")
         } else {
             GDLogInfo(.routeGuidance, "Route Guidance: Current waypoint is not known")
         }
-        
+
         nearestIntersectionKey = findNearestIntersection()
-        
+
         // Save state after everything else so that the stateChanged event gets sent when all state is done changing
         saveState()
-        
+
         GDATelemetry.track("routeguidance.next", with: ["context": telemetryContext, "automatic": "\(automatic)", "activity": AppContext.shared.motionActivityContext.currentActivity.rawValue])
     }
-    
+
     /// Updates the `waypointIndex` property of the state object to be the index of the
     /// previous waypoint and then saves the route guidance's state.
     func previousWaypoint() {
@@ -390,62 +405,62 @@ class RouteGuidance: BehaviorBase {
             // If the waypointIndex hasn't been set yet, initialize it to 0.
             state.waypointIndex = 0
         }
-        
+
         nearestIntersectionKey = findNearestIntersection()
-        
+
         saveState()
-        
+
         if let current = currentWaypoint {
             updateNowPlayingInfo(current)
             isArrivingAtWaypoint = false
-            
+
             delegate?.interruptCurrent(clearQueue: true, playHush: false)
             setOrTransitionBeacon(to: current.waypoint, skipAsyncFinish: true)
-            
+
             GDLogInfo(.routeGuidance, "Route Guidance: Current waypoint is #\(current.index)")
         } else {
             GDLogInfo(.routeGuidance, "Route Guidance: Current waypoint is not known")
         }
-        
+
         GDATelemetry.track("routeguidance.previous", with: ["context": telemetryContext, "activity": AppContext.shared.motionActivityContext.currentActivity.rawValue])
     }
-    
+
     func setBeacon(waypointIndex index: Int, enableAudio: Bool = true) {
         guard index < content.waypoints.count else {
             return
         }
-        
+
         state.waypointIndex = index
         let waypoint = content.waypoints[index]
         setOrTransitionBeacon(to: waypoint, enableAudio: enableAudio)
-        
+
         nearestIntersectionKey = findNearestIntersection()
-        
+
         saveState()
     }
-    
+
     private func setOrTransitionBeacon(to waypoint: LocationDetail, enableAudio: Bool = true, skipAsyncFinish: Bool = false) {
         // Notify the UI that we are transitioning between beacon locations
         NotificationCenter.default.post(name: .routeGuidanceTransitionStateChanged, object: nil, userInfo: [Key.isTransitioning: true])
-        
+
         // Check if a beacon has already been set - meaning that we are transitioning from one waypoint to another
         guard AppContext.shared.spatialDataContext.destinationManager.isDestinationSet else {
             completeSetBeacon(waypoint: waypoint, enableAudio: enableAudio)
             return
         }
-        
+
         // Ensure the beacon audio turns off when the app enters sleep mode
         if skipAsyncFinish && isBeaconAudioEnabled {
             // Toggle the audio off so that the next beacon starts immediately
             AppContext.shared.spatialDataContext.destinationManager.toggleDestinationAudio(forceMelody: false)
         }
-        
+
         // Make sure the beacon is currently playing
         guard isBeaconAsync, let id = AppContext.shared.spatialDataContext.destinationManager.beaconPlayerId else {
             if !isBeaconAsync && isBeaconAudioEnabled {
                 AppContext.shared.spatialDataContext.destinationManager.toggleDestinationAudio(false, forceMelody: true)
             }
-            
+
             let event: Event
             if isArrivingAtWaypoint {
                 // If arriving when the beacon is muted, then kick off the arrival callouts immediately
@@ -457,22 +472,22 @@ class RouteGuidance: BehaviorBase {
                 completeSetBeacon(waypoint: waypoint, enableAudio: enableAudio)
                 event = WaypointDepartureEvent(progress)
             }
-            
+
             DispatchQueue.main.async {
                 self.delegate?.process(event)
             }
-            
+
             return
         }
-        
+
         // Otherwise, we need to start the transition from the beacon for the previous waypoint
         // to the beacon for the subsequent waypoint by first stopping the current beacon. So save
         // the arguments for the next beacon and clear the current beacon. As soon as the beacon is
         // stopped, we will complete the process to start the next beacon.
         pendingBeaconArgs = .init(id: id, waypoint: waypoint, enableAudio: enableAudio)
-        
+
         GDLogInfo(.routeGuidance, "Start transition to next route beacon...")
-        
+
         do {
             try AppContext.shared.spatialDataContext.destinationManager.clearDestination(logContext: "route_guidance.set_beacon")
             GDLogInfo(.routeGuidance, "Awaiting finish of current route beacon...")
@@ -480,46 +495,46 @@ class RouteGuidance: BehaviorBase {
             GDLogError(.routeGuidance, "Error: Unable to remove current beacon in Route Guidance!")
         }
     }
-    
+
     private func completeSetBeacon(waypoint: LocationDetail, enableAudio: Bool) {
         guard let userLocation = userLocation ?? AppContext.shared.geolocationManager.location else {
             return
         }
-        
+
         guard let location = waypoint.source.closestLocation(from: userLocation, useEntranceIfAvailable: true) else {
             return
         }
-        
+
         // Start checking for distance callouts when we set the beacon
         delegate?.process(BeginWaypointDistanceCalloutsEvent(user: userLocation, waypoint: location))
-        
+
         do {
             let manager = AppContext.shared.spatialDataContext.destinationManager
-            
+
             if let markerId = waypoint.markerId {
                 try manager.setDestination(referenceID: markerId, enableAudio: enableAudio, userLocation: userLocation, logContext: "route")
             } else {
                 try manager.setDestination(location: location, behavior: waypoint.displayName, enableAudio: enableAudio, userLocation: userLocation, logContext: "route")
             }
-            
+
             // Ensure the beacon audio turns on when the waypoint changes
             if enableAudio && !manager.isAudioEnabled {
                 manager.toggleDestinationAudio(forceMelody: true)
             }
-            
+
             if let current = currentWaypoint {
                 updateNowPlayingInfo(current)
             }
-            
+
             GDLogInfo(.routeGuidance, "Finished setting route beacon")
         } catch {
             GDLogError(.routeGuidance, "Error: Unable to set beacon in Route Guidance!")
         }
-        
+
         // Once the new beacon has been set, indicate that the transition is complete
         NotificationCenter.default.post(name: .routeGuidanceTransitionStateChanged, object: nil, userInfo: [Key.isTransitioning: false])
     }
-    
+
     private func clearBeacon() {
         if AppContext.shared.spatialDataContext.destinationManager.isDestinationSet {
             do {
@@ -530,7 +545,7 @@ class RouteGuidance: BehaviorBase {
             }
         }
     }
-    
+
     private func updateNowPlayingInfo(_ current: (index: Int, waypoint: LocationDetail)?) {
         guard let current = current,
               let userLocation = userLocation ?? AppContext.shared.geolocationManager.location,
@@ -538,41 +553,41 @@ class RouteGuidance: BehaviorBase {
             AudioSessionManager.removeNowPlayingInfo()
             return
         }
-        
+
         let distance = location.distance(from: userLocation)
         let formattedDistance = LanguageFormatter.formattedDistance(from: distance)
-        
+
         AudioSessionManager.setNowPlayingInfo(title: content.displayName,
                                               subtitle: current.waypoint.displayName,
                                               secondarySubtitle: formattedDistance)
     }
-    
+
     private func findNearestIntersection() -> String? {
         guard let current = currentWaypoint?.waypoint.location else {
             return nil
         }
-        
+
         guard let dataView = spatialDataContext.getDataView(for: current, searchDistance: IntersectionGenerator.arrivalDistance * 2) else {
             return nil
         }
-        
+
         return dataView.intersections
             .map({ (intersection: $0, distance: $0.location.distance(from: current)) })
             .sorted(by: { $0.distance < $1.distance })
             .first(where: { $0.intersection.isMainIntersection(context: AppContext.secondaryRoadsContext) })?
             .intersection.key
     }
-    
+
     private func saveState(finalize: Bool = false) {
         if let previous = lastSaveTime, !state.isFinal {
             state.totalTime += Date().timeIntervalSince(previous)
             lastSaveTime = Date()
         }
-        
+
         if finalize {
             state.isFinal = true
         }
-        
+
         do {
             try state.save(id: content.id)
             NotificationCenter.default.post(name: Notification.Name.routeGuidanceStateChanged, object: self)

--- a/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidance.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidance.swift
@@ -63,6 +63,7 @@ class RouteGuidance: BehaviorBase {
     private var isFinished = false
     /// Receives `dynamicPlayerFinished` events
     private var beaconObserver: AnyCancellable?
+    private var shouldRestoreBeaconAudioOnWake = false
     /// Unless `shouldResume = true`, the route's state will be reset each time the route is activated
     var shouldResume = false
 
@@ -131,11 +132,6 @@ class RouteGuidance: BehaviorBase {
     }
 
     override func activate(with parent: Behavior?) {
-        let gen = RouteGuidanceGenerator(self, motionActivity: motionActivity, alreadyCompleted: progress.isDone)
-
-        manualGenerators.append(gen)
-        autoGenerators.append(gen)
-
         if case .database(let id) = content.source {
             do {
                 try Route.updateLastSelectedDate(id: id)
@@ -144,12 +140,19 @@ class RouteGuidance: BehaviorBase {
             }
         }
 
+        pendingBeaconArgs = nil
+        isArrivingAtWaypoint = false
+
         if shouldResume {
             // Do not reset the route state
             // Reset `shouldResume`
             shouldResume = false
+            arrivedAtFinalWaypoint = state.isFinal
+            isFinished = state.isFinal
         } else {
             // Reset the route state
+            arrivedAtFinalWaypoint = false
+            isFinished = false
             state.totalTime = 0.0
             state.isFinal = false
             state.waypointIndex = 0
@@ -172,6 +175,11 @@ class RouteGuidance: BehaviorBase {
         guard let current = currentWaypoint else {
             return
         }
+
+        let gen = RouteGuidanceGenerator(self, motionActivity: motionActivity, alreadyCompleted: progress.isDone)
+
+        manualGenerators.append(gen)
+        autoGenerators.append(gen)
 
         // Make sure there isn't an existing beacon when we start the first route beacon
         if AppContext.shared.spatialDataContext.destinationManager.isDestinationSet {
@@ -246,6 +254,7 @@ class RouteGuidance: BehaviorBase {
         nearestIntersectionKey = nil
 
         saveState()
+        lastSaveTime = nil
         clearBeacon()
         updateNowPlayingInfo(nil)
 
@@ -260,11 +269,13 @@ class RouteGuidance: BehaviorBase {
         let manager = AppContext.shared.spatialDataContext.destinationManager
 
         // Ensure the beacon audio turns off when the app enters sleep mode
-        if manager.isAudioEnabled {
+        shouldRestoreBeaconAudioOnWake = manager.isAudioEnabled
+        if shouldRestoreBeaconAudioOnWake {
             manager.toggleDestinationAudio(forceMelody: false)
         }
 
         saveState()
+        lastSaveTime = nil
     }
 
     override func wake() {
@@ -275,7 +286,10 @@ class RouteGuidance: BehaviorBase {
 
         // Ensure the beacon audio turns on when the app wakes up
         let manager = AppContext.shared.spatialDataContext.destinationManager
-        manager.toggleDestinationAudio(forceMelody: true)
+        if shouldRestoreBeaconAudioOnWake && !manager.isAudioEnabled {
+            manager.toggleDestinationAudio(forceMelody: true)
+        }
+        shouldRestoreBeaconAudioOnWake = false
     }
 
     /// Adds the index of the current waypoint to the visited waypoints and then switches to
@@ -426,7 +440,7 @@ class RouteGuidance: BehaviorBase {
     }
 
     func setBeacon(waypointIndex index: Int, enableAudio: Bool = true) {
-        guard index < content.waypoints.count else {
+        guard index >= 0 && index < content.waypoints.count else {
             return
         }
 
@@ -492,16 +506,24 @@ class RouteGuidance: BehaviorBase {
             try AppContext.shared.spatialDataContext.destinationManager.clearDestination(logContext: "route_guidance.set_beacon")
             GDLogInfo(.routeGuidance, "Awaiting finish of current route beacon...")
         } catch {
+            pendingBeaconArgs = nil
+            NotificationCenter.default.post(name: .routeGuidanceTransitionStateChanged, object: nil, userInfo: [Key.isTransitioning: false])
             GDLogError(.routeGuidance, "Error: Unable to remove current beacon in Route Guidance!")
         }
     }
 
     private func completeSetBeacon(waypoint: LocationDetail, enableAudio: Bool) {
+        defer {
+            NotificationCenter.default.post(name: .routeGuidanceTransitionStateChanged, object: nil, userInfo: [Key.isTransitioning: false])
+        }
+
         guard let userLocation = userLocation ?? AppContext.shared.geolocationManager.location else {
+            GDLogError(.routeGuidance, "Error: Unable to set route beacon without a user location!")
             return
         }
 
         guard let location = waypoint.source.closestLocation(from: userLocation, useEntranceIfAvailable: true) else {
+            GDLogError(.routeGuidance, "Error: Unable to resolve route waypoint location!")
             return
         }
 
@@ -530,9 +552,6 @@ class RouteGuidance: BehaviorBase {
         } catch {
             GDLogError(.routeGuidance, "Error: Unable to set beacon in Route Guidance!")
         }
-
-        // Once the new beacon has been set, indicate that the transition is complete
-        NotificationCenter.default.post(name: .routeGuidanceTransitionStateChanged, object: nil, userInfo: [Key.isTransitioning: false])
     }
 
     private func clearBeacon() {

--- a/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidanceGenerator.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidanceGenerator.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -14,7 +15,7 @@ class RouteGuidanceReadyEvent: StateChangedEvent { }
 class BeginWaypointDistanceCalloutsEvent: StateChangedEvent {
     let userLocation: CLLocation
     let waypointLocation: CLLocation
-    
+
     init(user: CLLocation, waypoint: CLLocation) {
         userLocation = user
         waypointLocation = waypoint
@@ -23,7 +24,7 @@ class BeginWaypointDistanceCalloutsEvent: StateChangedEvent {
 
 class WaypointArrivalEvent: StateChangedEvent {
     let progress: RouteProgress
-    
+
     init(_ progress: RouteProgress) {
         self.progress = progress
     }
@@ -31,65 +32,74 @@ class WaypointArrivalEvent: StateChangedEvent {
 
 class WaypointDepartureEvent: StateChangedEvent {
     let progress: RouteProgress
-    
+
     init(_ progress: RouteProgress) {
         self.progress = progress
     }
 }
+
+class RouteWaypointCalloutEvent: UserInitiatedEvent { }
 
 extension Notification.Name {
     static let routeWaypointArrived = Notification.Name("GDARouteWaypointArrivalOccurred")
 }
 
 class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
-    
+
     struct Key {
         static let markerId = "markerId"
     }
 
     private let distanceCalloutFilter: BeaconUpdateFilter
     private let arrivalDistance: CLLocationDistance = 12.0
-    
+
     private var currentActivationGroupID: UUID?
     private var currentArrivalGroupID: UUID?
     private var currentDepartureGroupID: UUID?
     private var currentDistanceGroupID: UUID?
     private var currentIntersectionGroupID: UUID?
-    
+
     private var isGuidanceReady: Bool = false
     private var lastWaypoint: (index: Int, waypoint: LocationDetail)?
     private var lastWasPreviouslyVisited: Bool = false
     private let alreadyCompleted: Bool
     private var shouldDeactivate: Bool = false
     private var awaitingNextWaypoint: Bool = true
-    
+
     /// Flag that indicates when the generator is currently awaiting departure callouts to complete. This
     /// is set to `true` when arrival callouts have been triggered (meaning the asynchronous process that
     /// will result in departure callouts eventually has been initiated). Waypoint distance callouts should
     /// not occur when this flag is set to `true`.
     private var awaitingDepartureCalloutCompletion = false
-    
+
     private var pendingIntersectionArrivalEvent: IntersectionArrivalEvent?
     private var pendingWaypointArrivalEvent: WaypointArrivalEvent?
-    
+
     var canInterrupt: Bool = false
-    
+
     private unowned let owner: RouteGuidance
-    
+
     init(_ owner: RouteGuidance, motionActivity: MotionActivityProtocol, alreadyCompleted: Bool) {
         self.owner = owner
         self.alreadyCompleted = alreadyCompleted
         distanceCalloutFilter = BeaconUpdateFilter(updateDistance: 10.0 ..< 25.0, beaconDistance: 12.0 ..< 100.0, motionActivity: motionActivity)
     }
-    
+
     func cancelCalloutsForEntity(id: String) {
         // Intentional No-Op
     }
-    
+
     func respondsTo(_ event: UserInitiatedEvent) -> Bool {
-        return event is BehaviorActivatedEvent
+        switch event {
+        case is BehaviorActivatedEvent,
+            is RouteWaypointCalloutEvent:
+            return true
+
+        default:
+            return false
+        }
     }
-    
+
     func respondsTo(_ event: StateChangedEvent) -> Bool {
         switch event {
         case is LocationUpdatedEvent,
@@ -99,36 +109,43 @@ class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
             is WaypointDepartureEvent,
             is IntersectionArrivalEvent:
             return true
-            
+
         default:
             return false
         }
     }
-    
+
     func handle(event: UserInitiatedEvent, verbosity: Verbosity) -> HandledEventAction? {
         switch event {
         case is BehaviorActivatedEvent:
             owner.addBlocked(auto: AutoCalloutGenerator.self)
             return .noAction
-            
+
+        case is RouteWaypointCalloutEvent:
+            guard let group = generateManualWaypointCallout() else {
+                return .noAction
+            }
+
+            return .playCallouts(group)
+
         default:
             return nil
         }
     }
-    
+
     func handle(event: StateChangedEvent, verbosity: Verbosity) -> HandledEventAction? {
         switch event {
         case let locationEvent as LocationUpdatedEvent:
             guard isGuidanceReady else {
                 return nil
             }
-            
+
             // Ignore location updates while we are waiting for the arrival callouts and subsequent departure
             // callouts to finish (i.e. when we are transitioning between beacons).
             guard !awaitingNextWaypoint else {
                 return nil
             }
-            
+
             // Check to see if the user has arrived at the current waypoint. Rather than directly generating
             // callouts now, instead signal to the RouteGuidance behavior that the current waypoint has been
             // completed. This will cause the current beacon to be finished (playing the arrival melody) and
@@ -137,25 +154,25 @@ class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
                 awaitingNextWaypoint = true
                 return .noAction
             }
-            
+
             // Don't start doing waypoint distance callouts until the departure callouts are complete
             guard !awaitingDepartureCalloutCompletion else {
                 return .noAction
             }
-            
+
             guard let callouts = generateDistanceCallouts(for: locationEvent, verbosity: verbosity) else {
                 return .noAction
             }
-            
+
             return .playCallouts(callouts)
-        
+
         case is RouteGuidanceReadyEvent:
             isGuidanceReady = true
-            
+
             let progress = owner.progress
-            
+
             var callouts: [CalloutProtocol] = []
-            
+
             if let current = owner.currentWaypoint {
                 callouts.append(WaypointDepartureCallout(index: current.index,
                                                          waypoint: current.waypoint,
@@ -164,39 +181,39 @@ class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
             } else {
                 callouts.append(StringCallout(.routeGuidance, GDLocalizedString("behavior.scavenger_hunt.callout.started")))
             }
-            
+
             let group = CalloutGroup(callouts, action: .interruptAndClear, playModeSounds: false, logContext: "scavenger_hunt.hunt_started")
             currentActivationGroupID = group.id
             group.delegate = self
-            
+
             return .playCallouts(group)
-            
+
         case let event as BeginWaypointDistanceCalloutsEvent:
             // Initialize the beacon callouts for the current beacon
             distanceCalloutFilter.start(beaconLocation: event.waypointLocation, shouldIgnoreFirstUpdate: true)
             awaitingNextWaypoint = false
             return .noAction
-            
+
         case let event as WaypointArrivalEvent:
             guard currentIntersectionGroupID == nil else {
                 awaitingDepartureCalloutCompletion = true
                 pendingWaypointArrivalEvent = event
                 return .noAction
             }
-            
+
             guard let callouts = generateArrivalCallouts(event) else {
                 return .noAction
             }
-            
+
             return .playCallouts(callouts)
-            
+
         case let event as WaypointDepartureEvent:
             guard let callouts = generateDepartureCallouts(event) else {
                 return .noAction
             }
-            
+
             return .playCallouts(callouts)
-            
+
         case let event as IntersectionArrivalEvent:
             // If we are in the middle of a transition between beacons, or we are performing the
             // initial callouts when the route starts, we should wait to do the intersection callout
@@ -205,76 +222,76 @@ class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
                 pendingIntersectionArrivalEvent = event
                 return .noAction
             }
-            
+
             let callout = IntersectionCallout(.intersection, event.key, event.isRoundabout, event.heading)
-            
+
             GDATelemetry.track("callout", with: ["context": "intersection.arrival",
                                                  "type": callout.logCategory,
                                                  "activity": AppContext.shared.motionActivityContext.currentActivity.rawValue,
                                                  "audio.output": AppContext.shared.audioEngine.outputType])
-            
+
             let group = CalloutGroup([callout], action: .interruptAndClear, logContext: "intersections")
             currentIntersectionGroupID = group.id
             group.delegate = self
             return .playCallouts(group)
-            
+
         default:
             return nil
         }
     }
-    
+
     private func checkArrival(for locationEvent: LocationUpdatedEvent, verbosity: Verbosity) -> Bool {
         // Make sure we currently have a flag
         guard let current = owner.currentWaypoint  else {
             return false
         }
-        
+
         let distance = locationEvent.location.distance(from: current.waypoint.location)
-        
+
         // When the user gets within 40 meters of the waypoint, block other callouts to prevent
         // the route guidance callouts from being poorly timed.
         if distance < 40.0 && !owner.blockedAutoGenerators.contains(where: { $0 == AutoCalloutGenerator.self }) {
             GDLogInfo(.routeGuidance, "Blocking auto callouts")
             owner.addBlocked(auto: AutoCalloutGenerator.self)
         }
-        
+
         guard distance < arrivalDistance else {
             return false
         }
-        
+
         return arrive(at: current, userLocation: locationEvent.location)
     }
-    
+
     private func arrive(at current: (index: Int, waypoint: LocationDetail), userLocation: CLLocation) -> Bool {
         let previouslyVisited = owner.state.visited.contains(current.index)
-        
+
         // Complete the current flag and get the progress object
         guard owner.completeCurrentWaypoint() else {
             return false
         }
-        
+
         lastWaypoint = current
         lastWasPreviouslyVisited = previouslyVisited
-        
+
         // Update the distance callout filter since this callout also includes a distance component
         distanceCalloutFilter.didUpdate(location: userLocation, success: true)
-        
+
         return true
     }
-    
+
     private func generateArrivalCallouts(_ event: WaypointArrivalEvent) -> CalloutGroup? {
         guard let previous = lastWaypoint else {
             return nil
         }
-        
+
         // Let the automatic callout context know that this marker has been called out so it doesn't
         // also attempt to call it out
         if let id = previous.waypoint.markerId {
             NotificationCenter.default.post(name: .routeWaypointArrived, object: nil, userInfo: [Key.markerId: id])
         }
-        
+
         awaitingDepartureCalloutCompletion = true
-        
+
         let callouts: [CalloutProtocol]  = [
             WaypointArrivalCallout(index: previous.index,
                                    waypoint: previous.waypoint,
@@ -282,148 +299,164 @@ class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
                                    previouslyVisited: lastWasPreviouslyVisited,
                                    isAdaptiveSportsActivity: owner.isAdaptiveSportsEvent)
         ]
-        
+
         let group = CalloutGroup(callouts, logContext: "route_guidance.arrival_callout")
-        
+
         currentArrivalGroupID = group.id
         group.delegate = self
-        
+
         GDLogInfo(.routeGuidance, "Created arrival callout group \(group.id)")
-        
+
         if event.progress.isDone {
             shouldDeactivate = true
         }
-        
+
         return group
     }
-    
+
     private func generateDepartureCallouts(_ event: WaypointDepartureEvent) -> CalloutGroup? {
         guard let next = event.progress.currentWaypoint else {
             return nil
         }
-        
+
         let callouts: [CalloutProtocol] = [
             WaypointDepartureCallout(index: next.index,
                                      waypoint: next.waypoint,
                                      progress: event.progress,
                                      isAutomatic: true)
         ]
-        
+
         let group = CalloutGroup(callouts, logContext: "route_guidance.departure_callout")
-        
+
         currentDepartureGroupID = group.id
         group.delegate = self
-        
+
         GDLogInfo(.routeGuidance, "Created departure callout group \(group.id)")
-        
+
         return group
     }
-    
+
     private func generateDistanceCallouts(for locationEvent: LocationUpdatedEvent, verbosity: Verbosity) -> CalloutGroup? {
         guard distanceCalloutFilter.shouldUpdate(location: locationEvent.location) else {
             return nil
         }
-        
+
         // Make sure we currently have a flag
         guard let current = owner.currentWaypoint else {
             return nil
         }
-        
+
         // User has passed the distance limits so we should do another distance callout
         distanceCalloutFilter.isUpdating(location: locationEvent.location)
-        
+
         let callouts = [WaypointDistanceCallout(index: current.index, waypoint: current.waypoint)]
         let group = CalloutGroup(callouts, logContext: "route_guidance.distance_callout")
-        
+
         currentDistanceGroupID = group.id
         group.delegate = self
-        
+
         GDLogInfo(.routeGuidance, "Created distance callout group \(group.id)")
-        
+
+        return group
+    }
+
+    private func generateManualWaypointCallout() -> CalloutGroup? {
+        guard let current = owner.currentWaypoint else {
+            return nil
+        }
+
+        let callouts = [WaypointDistanceCallout(index: current.index, waypoint: current.waypoint)]
+        let group = CalloutGroup(callouts, action: .interruptAndClear, logContext: "route_guidance.manual_waypoint_callout")
+
+        currentDistanceGroupID = group.id
+        group.delegate = self
+
+        GDLogInfo(.routeGuidance, "Created manual waypoint callout group \(group.id)")
+
         return group
     }
 }
 
 extension RouteGuidanceGenerator: CalloutGroupDelegate {
-    
+
     func isCalloutWithinRegionToLive(_ callout: CalloutProtocol) -> Bool {
         return true
     }
-    
+
     func calloutSkipped(_ callout: CalloutProtocol) {
         // No-Op
     }
-    
+
     func calloutStarting(_ callout: CalloutProtocol) {
         // No-op
     }
-    
+
     func calloutFinished(_ callout: CalloutProtocol, completed: Bool) {
         // No-op
     }
-    
+
     func calloutsSkipped(for group: CalloutGroup) {
         clearFilter(for: group)
         GDLogInfo(.routeGuidance, "Callouts skipped \(group.id)")
     }
-    
+
     func calloutsStarted(for group: CalloutGroup) {
         GDLogInfo(.routeGuidance, "Callouts started \(group.id)")
     }
-    
+
     func calloutsCompleted(for group: CalloutGroup, finished: Bool) {
         defer {
             clearFilter(for: group)
         }
-        
+
         GDLogInfo(.routeGuidance, "Callouts completed \(group.id)")
-        
+
         switch group.id {
         case currentActivationGroupID:
             owner.removeBlocked(auto: AutoCalloutGenerator.self)
-            
+
             // If there is a pending intersection arrival callout, process it now
             if let pending = pendingIntersectionArrivalEvent {
                 pendingIntersectionArrivalEvent = nil
-                
+
                 DispatchQueue.main.async { [weak self] in
                     self?.owner.delegate?.process(pending)
                 }
             }
-            
+
         case currentIntersectionGroupID:
             if let pending = pendingWaypointArrivalEvent {
                 pendingWaypointArrivalEvent = nil
-                
+
                 DispatchQueue.main.async { [weak self] in
                     self?.owner.delegate?.process(pending)
                 }
             }
-            
+
         case currentDepartureGroupID:
             // After departure callouts are finished, we can let regular automatic callouts resume again
             if owner.blockedAutoGenerators.contains(where: { $0 == AutoCalloutGenerator.self }) {
                 GDLogInfo(.routeGuidance, "Allow auto callouts again")
                 owner.removeBlocked(auto: AutoCalloutGenerator.self)
             }
-            
+
             // Allow distance callouts to resume
             awaitingDepartureCalloutCompletion = false
-            
+
             // If there is a pending intersection arrival callout, process it now
             if let pending = pendingIntersectionArrivalEvent {
                 pendingIntersectionArrivalEvent = nil
-                
+
                 DispatchQueue.main.async { [weak self] in
                     self?.owner.delegate?.process(pending)
                 }
             }
-            
+
         case currentArrivalGroupID:
             guard !alreadyCompleted else {
                 return
             }
-            
+
             if shouldDeactivate {
                 AppContext.shared.eventProcessor.deactivateCustom()
             } else {
@@ -433,12 +466,12 @@ extension RouteGuidanceGenerator: CalloutGroupDelegate {
                     self?.owner.finishTransitioningBeacon()
                 }
             }
-            
+
         default:
             break
         }
     }
-    
+
     private func clearFilter(for group: CalloutGroup) {
         // Signal to the appropriate filter that the update is done
         if let id = currentDistanceGroupID, group.id == id {

--- a/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidanceGenerator.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidanceGenerator.swift
@@ -366,7 +366,13 @@ class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
             return nil
         }
 
-        let callouts = [WaypointDistanceCallout(index: current.index, waypoint: current.waypoint)]
+        let callouts: [CalloutProtocol]
+        if let beaconId = current.waypoint.beaconId ?? AppContext.shared.spatialDataContext.destinationManager.destinationKey {
+            callouts = [DestinationCallout(.auto, beaconId)]
+        } else {
+            callouts = [WaypointDistanceCallout(index: current.index, waypoint: current.waypoint)]
+        }
+
         let group = CalloutGroup(callouts, action: .interruptAndClear, logContext: "route_guidance.manual_waypoint_callout")
 
         currentManualWaypointGroupID = group.id

--- a/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidanceGenerator.swift
+++ b/apps/ios/GuideDogs/Code/Behaviors/Route Guidance/RouteGuidanceGenerator.swift
@@ -57,6 +57,7 @@ class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
     private var currentArrivalGroupID: UUID?
     private var currentDepartureGroupID: UUID?
     private var currentDistanceGroupID: UUID?
+    private var currentManualWaypointGroupID: UUID?
     private var currentIntersectionGroupID: UUID?
 
     private var isGuidanceReady: Bool = false
@@ -368,7 +369,7 @@ class RouteGuidanceGenerator: AutomaticGenerator, ManualGenerator {
         let callouts = [WaypointDistanceCallout(index: current.index, waypoint: current.waypoint)]
         let group = CalloutGroup(callouts, action: .interruptAndClear, logContext: "route_guidance.manual_waypoint_callout")
 
-        currentDistanceGroupID = group.id
+        currentManualWaypointGroupID = group.id
         group.delegate = self
 
         GDLogInfo(.routeGuidance, "Created manual waypoint callout group \(group.id)")
@@ -477,6 +478,8 @@ extension RouteGuidanceGenerator: CalloutGroupDelegate {
         if let id = currentDistanceGroupID, group.id == id {
             distanceCalloutFilter.didUpdate(success: true)
             currentDistanceGroupID = nil
+        } else if let id = currentManualWaypointGroupID, group.id == id {
+            currentManualWaypointGroupID = nil
         } else if let id = currentDepartureGroupID, group.id == id {
             currentDepartureGroupID = nil
         } else if let id = currentArrivalGroupID, group.id == id {

--- a/apps/ios/GuideDogs/Code/Visual UI/Controls/Beacon/BeaconTitleViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Controls/Beacon/BeaconTitleViewController.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -335,9 +336,7 @@ private extension UIAccessibilityCustomAction {
     
     static func callout(_ beacon: BeaconDetail) -> UIAccessibilityCustomAction {
         return UIAccessibilityCustomAction(name: BeaconAction.callout.text, actionHandler: { _ in
-            BeaconActionHandler.callout(detail: beacon)
-            
-            return true
+            return BeaconActionHandler.callout(detail: beacon)
         })
     }
     

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Beacon/BeaconActionHandler.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Beacon/BeaconActionHandler.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -11,7 +12,7 @@ import CoreLocation
 import SwiftUI
 
 struct BeaconActionHandler {
-    
+
     ///
     /// `createMarker(detail: BeaconDetail)`
     ///
@@ -23,26 +24,26 @@ struct BeaconActionHandler {
         guard let key = detail.locationDetail.beaconId else {
             return nil
         }
-        
+
         guard let beacon = SpatialDataCache.referenceEntityByKey(key) else {
             // Failed to fetch beacon
             return nil
         }
-        
+
         guard beacon.isTemp else {
             return nil
         }
-        
+
         let config = EditMarkerConfig(detail: LocationDetail(marker: beacon),
                                       route: nil,
                                       context: "beacon_view",
                                       addOrUpdateAction: .popViewController,
                                       deleteAction: nil,
                                       leftBarButtonItemIsHidden: false)
-        
+
         return MarkerEditViewRepresentable(config: config).makeViewController()
     }
-    
+
     ///
     /// `callout(detail: BeaconDetail)`
     ///
@@ -50,10 +51,19 @@ struct BeaconActionHandler {
     ///
     /// queues a call out for the given audio beacon
     ///
-    static func callout(detail: BeaconDetail) {
-        callout(detail: detail.locationDetail)
+    @discardableResult
+    static func callout(detail: BeaconDetail) -> Bool {
+        if let routeDetail = detail.routeDetail {
+            guard let routeGuidance = routeDetail.guidance else {
+                return false
+            }
+
+            return routeGuidance.callOutCurrentWaypoint()
+        }
+
+        return callout(detail: detail.locationDetail)
     }
-    
+
     ///
     /// `callout(detail: LocationDetail)`
     ///
@@ -61,15 +71,17 @@ struct BeaconActionHandler {
     ///
     /// queues a call out for the given audio beacon
     ///
-    static func callout(detail: LocationDetail) {
+    @discardableResult
+    static func callout(detail: LocationDetail) -> Bool {
         guard let key = detail.beaconId else {
-            return
+            return false
         }
-        
+
         AppContext.process(BeaconCalloutEvent(beaconId: key, logContext: "home_screen"))
         GDATelemetry.track("beacon.callout")
+        return true
     }
-    
+
     ///
     /// `toggleAudio`
     ///
@@ -80,11 +92,11 @@ struct BeaconActionHandler {
             // Failed to toggle audio
             return
         }
-        
+
         let isAudioEnabled = AppContext.shared.spatialDataContext.destinationManager.isAudioEnabled
         GDATelemetry.track("beacon.toggle_audio", value: String(isAudioEnabled))
     }
-    
+
     ///
     /// `moreInformation(detail: BeaconDetail, userLocation: CLLocation)`
     ///
@@ -97,13 +109,13 @@ struct BeaconActionHandler {
     static func moreInformation(detail: BeaconDetail, userLocation: CLLocation?) {
         let dLabel = detail.labels.moreInformation(userLocation: userLocation)
         let moreInformation = dLabel.accessibilityText ?? dLabel.text
-        
+
         // Post accessibility annoucement
         UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: moreInformation)
-        
+
         GDATelemetry.track("beacon.more_info")
     }
-    
+
     ///
     /// `remove`
     ///
@@ -114,23 +126,23 @@ struct BeaconActionHandler {
             guard routeDetail.isGuidanceActive else {
                 return
             }
-            
+
             AppContext.shared.eventProcessor.deactivateCustom()
         } else {
             guard AppContext.shared.spatialDataContext.destinationManager.destinationKey == detail.locationDetail.beaconId else {
                 // There is no beacon to clear
                 return
             }
-            
+
             do {
                 // Try to remove the beacon
                 try AppContext.shared.spatialDataContext.destinationManager.clearDestination(logContext: "home_screen")
             } catch {
                 return
             }
-            
+
             GDLogActionInfo("Clear destination")
         }
     }
-    
+
 }

--- a/apps/ios/UnitTests/Behaviors/Route Guidance/RouteGuidanceTest.swift
+++ b/apps/ios/UnitTests/Behaviors/Route Guidance/RouteGuidanceTest.swift
@@ -209,12 +209,37 @@ class RouteGuidanceTest: XCTestCase {
         XCTAssertEqual(route.currentWaypoint!.waypoint.location.coordinate, activity.waypoints[3].coordinate)
         XCTAssertEqual(route.progress.completed, 0)
 
+        // Go to -1 (out of bound, so fails and stays at 3)
+        route.setBeacon(waypointIndex: -1, enableAudio: false)
+        XCTAssertNotNil(route.currentWaypoint)
+        XCTAssertEqual(route.currentWaypoint!.index, 3)
+        XCTAssertEqual(route.currentWaypoint!.waypoint.location.coordinate, activity.waypoints[3].coordinate)
+        XCTAssertEqual(route.progress.completed, 0)
+
         // Go back to 0
         route.setBeacon(waypointIndex: 0, enableAudio: false)
         XCTAssertNotNil(route.currentWaypoint)
         XCTAssertEqual(route.currentWaypoint!.index, 0)
         XCTAssertEqual(route.currentWaypoint!.waypoint.location.coordinate, activity.waypoints[0].coordinate)
         XCTAssertEqual(route.progress.completed, 0)
+
+        XCTAssertNil(route.deactivate())
+    }
+
+    func testSinglePointFreshActivationAfterCompletionResetsProgress() throws {
+        let route = RouteGuidance(RouteGuidanceTest.activity_single_waypoint(), spatialData: spatial, motion: motion)
+        route.activate(with: nil)
+        XCTAssert(route.completeCurrentWaypoint())
+        XCTAssertTrue(route.progress.isDone)
+        XCTAssertTrue(route.state.isFinal)
+
+        XCTAssertNil(route.deactivate())
+        route.activate(with: nil)
+
+        XCTAssertFalse(route.progress.isDone)
+        XCTAssertEqual(route.progress.completed, 0)
+        XCTAssertFalse(route.state.isFinal)
+        XCTAssertEqual(route.state.visited.count, 0)
 
         XCTAssertNil(route.deactivate())
     }

--- a/apps/ios/UnitTests/Behaviors/Route Guidance/RouteGuidanceTest.swift
+++ b/apps/ios/UnitTests/Behaviors/Route Guidance/RouteGuidanceTest.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Kai on 7/21/23.
 //  Copyright © 2023 Microsoft. All rights reserved.
+//  Copyright (c) Soundscape Community Contributors.
 //
 
 import XCTest
@@ -14,6 +15,16 @@ import CoreLocation
 
 
 class RouteGuidanceTest: XCTestCase {
+    class TestBehaviorDelegate: BehaviorDelegate {
+        var processedEvents: [Event] = []
+
+        func interruptCurrent(clearQueue: Bool, playHush: Bool) { }
+
+        func process(_ event: Event) {
+            processedEvents.append(event)
+        }
+    }
+
     class TestMotionActivity: MotionActivityProtocol {
         var isWalking: Bool = true
         var isInVehicle: Bool = false
@@ -28,24 +39,24 @@ class RouteGuidanceTest: XCTestCase {
         static var expansionPOISearchDistance: CLLocationDistance = SpatialDataContext.expansionPOISearchDistance
         static var refreshTimeInterval: TimeInterval = SpatialDataContext.refreshTimeInterval
         static var refreshDistanceInterval: CLLocationDistance = SpatialDataContext.refreshDistanceInterval
-        
+
         var motionActivityContext: MotionActivityProtocol
         var destinationManager: DestinationManagerProtocol
         var state: SpatialDataState = SpatialDataState.waitingForLocation
         var loadedSpatialData: Bool = false
         var currentTiles: [VectorTile] = []
-        
+
         init(_ motionActivity: MotionActivityProtocol, _ destination: DestinationManagerProtocol) {
             motionActivityContext = motionActivity
             destinationManager = destination
         }
-        
+
         func start() { }
         func stop() { }
         func clearCache() -> Bool {
             false
         }
-        
+
         func getDataView(for location: CLLocation, searchDistance: CLLocationDistance) -> SpatialDataViewProtocol? {
             nil
         }
@@ -55,14 +66,14 @@ class RouteGuidanceTest: XCTestCase {
         func getCurrentDataView(initialSearchDistance: CLLocationDistance, shouldExpandDataView: @escaping (SpatialDataViewProtocol) -> Bool) -> SpatialDataViewProtocol? {
             nil
         }
-        
+
         func updateSpatialData(at location: CLLocation, completion: @escaping () -> Void) -> Progress? {
             nil
         }
     }
-    
+
     // ----
-    
+
     let motion = TestMotionActivity()
     let destinationM = DestinationManager(userLocation: nil, audioEngine: AudioEngine(envSettings: TestAudioEnvironmentSettings(), mixWithOthers: true), collectionHeading: Heading(orderedBy: [], course: nil, deviceHeading: nil, userHeading: nil, geolocationManager: nil))
     var spatial: TestSpatialData!
@@ -97,7 +108,7 @@ class RouteGuidanceTest: XCTestCase {
         let loc_cw = currentWaypoint.waypoint.location.coordinate
         XCTAssertEqual(loc_cw.latitude, 0)
         XCTAssertEqual(loc_cw.longitude, 0)
-        
+
         let routeProgress = route.progress
         XCTAssertNotNil(routeProgress.currentWaypoint)
         XCTAssertEqual(routeProgress.currentWaypoint!.index, currentWaypoint.index)
@@ -109,22 +120,22 @@ class RouteGuidanceTest: XCTestCase {
         XCTAssertFalse(routeProgress.isDone)
         XCTAssertEqual(routeProgress.total, 1)
         XCTAssertEqual(routeProgress.percentComplete, 0) // calculated
-        
+
         // Because we created using the AuthoredActivityContent constructor for RouteGuidance, it always has the trailActivity type, which should result in the following:
         XCTAssertTrue(route.isAdaptiveSportsEvent)
         XCTAssertEqual(route.telemetryContext, "asevent")
-        
+
         XCTAssertNil(route.deactivate())
     }
-    
+
     func testSinglePointFinish() throws {
         let route = RouteGuidance(RouteGuidanceTest.activity_single_waypoint(), spatialData: spatial, motion: motion)
         route.activate(with: nil)
         XCTAssertNotNil(route.currentWaypoint)
         XCTAssertEqual(route.currentWaypoint!.index, 0)
-        
+
         // ----
-        
+
         XCTAssert(route.completeCurrentWaypoint())
         XCTAssertNotNil(route.currentWaypoint, "we should be on the last waypoint even though we are done")
         let progress = route.progress
@@ -134,40 +145,40 @@ class RouteGuidanceTest: XCTestCase {
         XCTAssertEqual(progress.total, 1)
         XCTAssertEqual(progress.completed, 1)
         XCTAssertEqual(progress.remaining, 0)
-        
+
         XCTAssertTrue(route.state.isFinal)
         XCTAssertEqual(route.state.visited.count, 1)
-        
+
         XCTAssertNil(route.deactivate())
     }
-    
+
     /// For `RouteGuidance.shouldResume`
     func testSinglePointResume() throws {
         let route = RouteGuidance(RouteGuidanceTest.activity_single_waypoint(), spatialData: spatial, motion: motion)
         route.activate(with: nil)
         XCTAssert(route.completeCurrentWaypoint())
-        
+
         // Assert 'before' state
         XCTAssertTrue(route.progress.isDone)
         XCTAssertEqual(route.progress.completed, 1)
         XCTAssertTrue(route.state.isFinal)
         XCTAssertEqual(route.state.visited.count, 1)
-        
+
         // ---
         route.shouldResume = true
         XCTAssertNil(route.deactivate())
         route.activate(with: nil)
         // ---
-        
+
         // Assert 'after' state (should be the same as 'before')
         XCTAssertTrue(route.progress.isDone)
         XCTAssertEqual(route.progress.completed, 1)
         XCTAssertTrue(route.state.isFinal)
         XCTAssertEqual(route.state.visited.count, 1)
-        
+
         XCTAssertNil(route.deactivate())
     }
-    
+
     /// Tests `RouteGuidance.setBeacon(waypointIndex:, enableAudio:)`
     func testSetBeacon() throws {
         let activity = RouteGuidanceTest.activity_random_waypoints(count: 5)
@@ -176,37 +187,80 @@ class RouteGuidanceTest: XCTestCase {
         XCTAssertNotNil(route.currentWaypoint)
         XCTAssertEqual(route.currentWaypoint!.index, 0)
         XCTAssertEqual(route.currentWaypoint!.waypoint.location.coordinate, activity.waypoints[0].coordinate)
-        
+
         // Go to 2
         route.setBeacon(waypointIndex: 2, enableAudio: false)
         XCTAssertNotNil(route.currentWaypoint)
         XCTAssertEqual(route.currentWaypoint!.index, 2)
         XCTAssertEqual(route.currentWaypoint!.waypoint.location.coordinate, activity.waypoints[2].coordinate)
         XCTAssertEqual(route.progress.completed, 0)
-        
+
         // Go to 3
         route.setBeacon(waypointIndex: 3, enableAudio: false)
         XCTAssertNotNil(route.currentWaypoint)
         XCTAssertEqual(route.currentWaypoint!.index, 3)
         XCTAssertEqual(route.currentWaypoint!.waypoint.location.coordinate, activity.waypoints[3].coordinate)
         XCTAssertEqual(route.progress.completed, 0)
-        
+
         // Go to 10 (out of bound, so fails and stays at 3)
         route.setBeacon(waypointIndex: 10, enableAudio: false)
         XCTAssertNotNil(route.currentWaypoint)
         XCTAssertEqual(route.currentWaypoint!.index, 3)
         XCTAssertEqual(route.currentWaypoint!.waypoint.location.coordinate, activity.waypoints[3].coordinate)
         XCTAssertEqual(route.progress.completed, 0)
-        
+
         // Go back to 0
         route.setBeacon(waypointIndex: 0, enableAudio: false)
         XCTAssertNotNil(route.currentWaypoint)
         XCTAssertEqual(route.currentWaypoint!.index, 0)
         XCTAssertEqual(route.currentWaypoint!.waypoint.location.coordinate, activity.waypoints[0].coordinate)
         XCTAssertEqual(route.progress.completed, 0)
-        
+
         XCTAssertNil(route.deactivate())
     }
-    
+
+    func testCallOutCurrentWaypointProcessesRouteWaypointCalloutEvent() throws {
+        let route = RouteGuidance(RouteGuidanceTest.activity_random_waypoints(count: 2), spatialData: spatial, motion: motion)
+        let delegate = TestBehaviorDelegate()
+        route.delegate = delegate
+
+        route.activate(with: nil)
+
+        XCTAssertTrue(route.callOutCurrentWaypoint())
+        XCTAssertTrue(delegate.processedEvents.first is RouteWaypointCalloutEvent)
+
+        XCTAssertNil(route.deactivate())
+    }
+
+    func testRouteWaypointCalloutEventGeneratesCurrentWaypointDistanceCallout() throws {
+        let route = RouteGuidance(RouteGuidanceTest.activity_random_waypoints(count: 2), spatialData: spatial, motion: motion)
+        route.activate(with: nil)
+
+        var handledActions: [HandledEventAction]?
+        route.handleEvent(RouteWaypointCalloutEvent()) { actions in
+            handledActions = actions
+        }
+
+        guard case let .playCallouts(group)? = handledActions?.first else {
+            XCTFail("Expected route waypoint callout event to play callouts")
+            return
+        }
+
+        XCTAssertEqual(group.action, .interruptAndClear)
+        XCTAssertEqual(group.logContext, "route_guidance.manual_waypoint_callout")
+        XCTAssertEqual(group.callouts.count, 1)
+
+        guard let callout = group.callouts.first as? WaypointDistanceCallout else {
+            XCTFail("Expected a waypoint distance callout")
+            return
+        }
+
+        XCTAssertEqual(callout.index, route.currentWaypoint?.index)
+        XCTAssertEqual(callout.waypoint.location.coordinate.latitude, route.currentWaypoint?.waypoint.location.coordinate.latitude)
+        XCTAssertEqual(callout.waypoint.location.coordinate.longitude, route.currentWaypoint?.waypoint.location.coordinate.longitude)
+
+        XCTAssertNil(route.deactivate())
+    }
+
     // TODO: There are definitely more tests we should add here
 }


### PR DESCRIPTION
## Summary
- route route-backed beacon callout actions through RouteGuidance instead of the generic BeaconCalloutGenerator path
- add a RouteWaypointCalloutEvent that generates an interrupting WaypointDistanceCallout for the current route waypoint
- return the real handled state from the VoiceOver custom action
- add route guidance unit coverage for the manual waypoint callout event

## Root cause
RouteGuidance blocks BeaconCalloutGenerator while active, so the VoiceOver “Call Out Beacon” action dispatched a generic BeaconCalloutEvent that route guidance intentionally suppressed for route waypoints.

## Notes
This commit also removes trailing whitespace in the touched files, so the whitespace-insensitive diff is smaller than the full diff.

## Test plan
- xcodebuild test -project apps/ios/GuideDogs.xcodeproj -scheme Soundscape -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/RouteGuidanceTest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved beacon state management and waypoint transition handling during route guidance
  * Refined audio callout sequencing at waypoint arrivals
  * Enhanced accessibility action response for beacon interactions

* **Improvements**
  * Better telemetry tracking for audio controls and beacon state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->