### PR TITLE
[codex] Bump aiohttp in data service

### DIFF
--- a/svcs/data/Dockerfile.ingest
+++ b/svcs/data/Dockerfile.ingest
@@ -1,14 +1,15 @@
 # Copyright (c) Microsoft Corporation.
+# Copyright (c) Soundscape Community Contributors.
 # Licensed under the MIT License.
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 as installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf -y update \
  && tdnf install -y dnf \
  && mkdir /staging \
- && dnf install -y --release=2.0 --installroot /staging prebuilt-ca-certificates wget python3 python3-pip python3-setuptools
+ && dnf install -y --release=3.0 --installroot /staging prebuilt-ca-certificates wget python3 python3-pip python3-setuptools
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 as imposm
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS imposm
 
 ENV IMPOSM_BINARY_RELEASE=0.11.1
 
@@ -17,7 +18,7 @@ RUN tdnf -y update \
  && mkdir -p /ingest/imposm3 \
  && wget -q -O - https://github.com/omniscale/imposm3/releases/download/v$IMPOSM_BINARY_RELEASE/imposm-$IMPOSM_BINARY_RELEASE-linux-x86-64.tar.gz | tar -xz --strip-components=1 -C /ingest/imposm3
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0 as final
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS final
 
 ENV PYTHONUNBUFFERED=true INGEST=/ingest EXTRADATA=/non_osm_data TILES=/tiles MAPPING=/mapping UPDATE_FREQUENCY=minute
 

--- a/svcs/data/Dockerfile.ingest
+++ b/svcs/data/Dockerfile.ingest
@@ -2,37 +2,29 @@
 # Copyright (c) Soundscape Community Contributors.
 # Licensed under the MIT License.
 
-FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
-
-RUN tdnf -y update \
- && tdnf install -y dnf \
- && mkdir /staging \
- && dnf install -y --release=3.0 --installroot /staging prebuilt-ca-certificates wget python3 python3-pip python3-setuptools
-
-FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS imposm
+FROM python:3.12-slim-bookworm AS assets
 
 ENV IMPOSM_BINARY_RELEASE=0.11.1
 
-RUN tdnf -y update \
- && tdnf install -y ca-certificates-microsoft wget tar gzip \
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates wget tar gzip \
  && mkdir -p /ingest/imposm3 \
- && wget -q -O - https://github.com/omniscale/imposm3/releases/download/v$IMPOSM_BINARY_RELEASE/imposm-$IMPOSM_BINARY_RELEASE-linux-x86-64.tar.gz | tar -xz --strip-components=1 -C /ingest/imposm3
+ && wget -q -O - https://github.com/omniscale/imposm3/releases/download/v$IMPOSM_BINARY_RELEASE/imposm-$IMPOSM_BINARY_RELEASE-linux-x86-64.tar.gz | tar -xz --strip-components=1 -C /ingest/imposm3 \
+ && wget -q -O /ingest/postgis-vt-util.sql https://raw.githubusercontent.com/mapbox/postgis-vt-util/master/postgis-vt-util.sql \
+ && rm -rf /var/lib/apt/lists/*
 
-FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS final
+FROM python:3.12-slim-bookworm AS final
 
 ENV PYTHONUNBUFFERED=true INGEST=/ingest EXTRADATA=/non_osm_data TILES=/tiles MAPPING=/mapping UPDATE_FREQUENCY=minute
 
-COPY --from=imposm /ingest/ $INGEST/
-COPY --from=installer /staging/ /
+COPY --from=assets /ingest/ $INGEST/
 
 COPY requirements.txt requirements_kubernetes.txt ingest.py ingest_non_osm.py kubescape.py extracts.json tilefunc.sql $INGEST/
 COPY soundscape/other/mapping.yml $MAPPING/mapping.yml
-RUN wget -q -O $INGEST/postgis-vt-util.sql https://raw.githubusercontent.com/mapbox/postgis-vt-util/master/postgis-vt-util.sql
 
-RUN /usr/bin/pip3 install -r $INGEST/requirements.txt -r $INGEST/requirements_kubernetes.txt
+RUN python -m pip install --no-cache-dir -r $INGEST/requirements.txt -r $INGEST/requirements_kubernetes.txt
 
-CMD  rm -f $TILES/*.pbf && rm -rf $TILES/imposm_cache $TILES/imposm_expired $TILES/imposm_diff && \
-    python3 $INGEST/ingest.py \
+CMD ["sh", "-c", "rm -f $TILES/*.pbf && rm -rf $TILES/imposm_cache $TILES/imposm_expired $TILES/imposm_diff && exec python $INGEST/ingest.py \
         --imposm $INGEST/imposm3/imposm \
         --mapping $MAPPING/mapping.yml \
         --where $GEN_REGIONS \
@@ -46,4 +38,4 @@ CMD  rm -f $TILES/*.pbf && rm -rf $TILES/imposm_cache $TILES/imposm_expired $TIL
         --delay $LOOP_TIME \
         --telemetry \
         --extradatadir $EXTRADATA \
-        $INGEST_FLAGS
+        $INGEST_FLAGS"]

--- a/svcs/data/Dockerfile.ingest
+++ b/svcs/data/Dockerfile.ingest
@@ -4,12 +4,15 @@
 
 FROM python:3.12-slim-bookworm AS final
 
-ENV PYTHONUNBUFFERED=true INGEST=/ingest EXTRADATA=/non_osm_data TILES=/tiles MAPPING=/mapping UPDATE_FREQUENCY=minute IMPOSM_BINARY_RELEASE=0.11.1
+ENV PYTHONUNBUFFERED=true INGEST=/ingest EXTRADATA=/non_osm_data TILES=/tiles MAPPING=/mapping UPDATE_FREQUENCY=minute IMPOSM_BINARY_RELEASE=0.11.1 IMPOSM_BINARY_SHA256=67b6c0e20379e8f3bf8eedaf0bc035420d4c38c54c9c698304a2bb3f9ec00260
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates wget tar gzip \
+ && wget -q -O /tmp/imposm.tar.gz https://github.com/omniscale/imposm3/releases/download/v$IMPOSM_BINARY_RELEASE/imposm-$IMPOSM_BINARY_RELEASE-linux-x86-64.tar.gz \
+ && echo "$IMPOSM_BINARY_SHA256  /tmp/imposm.tar.gz" | sha256sum -c - \
  && mkdir -p $INGEST/imposm3 \
- && wget -q -O - https://github.com/omniscale/imposm3/releases/download/v$IMPOSM_BINARY_RELEASE/imposm-$IMPOSM_BINARY_RELEASE-linux-x86-64.tar.gz | tar -xz --strip-components=1 -C $INGEST/imposm3 \
+ && tar -xzf /tmp/imposm.tar.gz --strip-components=1 -C $INGEST/imposm3 \
+ && rm /tmp/imposm.tar.gz \
  && wget -q -O $INGEST/postgis-vt-util.sql https://raw.githubusercontent.com/mapbox/postgis-vt-util/master/postgis-vt-util.sql \
  && rm -rf /var/lib/apt/lists/*
 

--- a/svcs/data/Dockerfile.ingest
+++ b/svcs/data/Dockerfile.ingest
@@ -2,26 +2,16 @@
 # Copyright (c) Soundscape Community Contributors.
 # Licensed under the MIT License.
 
-FROM python:3.12-slim-bookworm AS assets
+FROM python:3.12-slim-bookworm AS final
 
-ENV IMPOSM_BINARY_RELEASE=0.11.1
+ENV PYTHONUNBUFFERED=true INGEST=/ingest EXTRADATA=/non_osm_data TILES=/tiles MAPPING=/mapping UPDATE_FREQUENCY=minute IMPOSM_BINARY_RELEASE=0.11.1
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates wget tar gzip \
- && mkdir -p /ingest/imposm3 \
- && wget -q -O - https://github.com/omniscale/imposm3/releases/download/v$IMPOSM_BINARY_RELEASE/imposm-$IMPOSM_BINARY_RELEASE-linux-x86-64.tar.gz | tar -xz --strip-components=1 -C /ingest/imposm3 \
- && wget -q -O /ingest/postgis-vt-util.sql https://raw.githubusercontent.com/mapbox/postgis-vt-util/master/postgis-vt-util.sql \
+ && mkdir -p $INGEST/imposm3 \
+ && wget -q -O - https://github.com/omniscale/imposm3/releases/download/v$IMPOSM_BINARY_RELEASE/imposm-$IMPOSM_BINARY_RELEASE-linux-x86-64.tar.gz | tar -xz --strip-components=1 -C $INGEST/imposm3 \
+ && wget -q -O $INGEST/postgis-vt-util.sql https://raw.githubusercontent.com/mapbox/postgis-vt-util/master/postgis-vt-util.sql \
  && rm -rf /var/lib/apt/lists/*
-
-FROM python:3.12-slim-bookworm AS final
-
-ENV PYTHONUNBUFFERED=true INGEST=/ingest EXTRADATA=/non_osm_data TILES=/tiles MAPPING=/mapping UPDATE_FREQUENCY=minute
-
-RUN apt-get update \
- && apt-get install -y --no-install-recommends wget \
- && rm -rf /var/lib/apt/lists/*
-
-COPY --from=assets /ingest/ $INGEST/
 
 COPY requirements.txt requirements_kubernetes.txt ingest.py ingest_non_osm.py kubescape.py extracts.json tilefunc.sql $INGEST/
 COPY soundscape/other/mapping.yml $MAPPING/mapping.yml

--- a/svcs/data/Dockerfile.ingest
+++ b/svcs/data/Dockerfile.ingest
@@ -17,6 +17,10 @@ FROM python:3.12-slim-bookworm AS final
 
 ENV PYTHONUNBUFFERED=true INGEST=/ingest EXTRADATA=/non_osm_data TILES=/tiles MAPPING=/mapping UPDATE_FREQUENCY=minute
 
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends wget \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY --from=assets /ingest/ $INGEST/
 
 COPY requirements.txt requirements_kubernetes.txt ingest.py ingest_non_osm.py kubescape.py extracts.json tilefunc.sql $INGEST/

--- a/svcs/data/Dockerfile.tilesrv
+++ b/svcs/data/Dockerfile.tilesrv
@@ -2,21 +2,12 @@
 # Copyright (c) Soundscape Community Contributors.
 # Licensed under the MIT License.
 
-FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
-
-RUN tdnf -y update \
- && tdnf install -y dnf \
- && mkdir /staging \
- && dnf install -y --release=3.0 --installroot /staging prebuilt-ca-certificates python3 python3-pip
-
-FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS final
-
-COPY --from=installer /staging/ /
+FROM python:3.12-slim-bookworm AS final
 
 ENV PYTHONUNBUFFERED=true TILESRV=/tilesrv
 
 COPY requirements.txt gentiles.py $TILESRV/
 
-RUN pip3 install -r $TILESRV/requirements.txt
+RUN python -m pip install --no-cache-dir -r $TILESRV/requirements.txt
 
-ENTRYPOINT python3 /tilesrv/gentiles.py --verbose --dsn "$DSN"
+ENTRYPOINT ["sh", "-c", "exec python /tilesrv/gentiles.py --verbose --dsn \"$DSN\""]

--- a/svcs/data/Dockerfile.tilesrv
+++ b/svcs/data/Dockerfile.tilesrv
@@ -1,14 +1,15 @@
 # Copyright (c) Microsoft Corporation.
+# Copyright (c) Soundscape Community Contributors.
 # Licensed under the MIT License.
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 as installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf -y update \
  && tdnf install -y dnf \
  && mkdir /staging \
- && dnf install -y --release=2.0 --installroot /staging prebuilt-ca-certificates python3 python3-pip
+ && dnf install -y --release=3.0 --installroot /staging prebuilt-ca-certificates python3 python3-pip
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0 as final
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS final
 
 COPY --from=installer /staging/ /
 

--- a/svcs/data/requirements.txt
+++ b/svcs/data/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.5
+aiohttp==3.14.1
 aiopg==1.4.0
 Faker==37.1.0
 prometheus-client==0.21.1

--- a/svcs/data/requirements.txt
+++ b/svcs/data/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.4
+aiohttp==3.13.5
 aiopg==1.4.0
 Faker==37.1.0
 prometheus-client==0.21.1


### PR DESCRIPTION
## Summary
- Bump `svcs/data` from `aiohttp 3.13.4` to `aiohttp 3.14.1`, the latest patched 3.14.x release.
- Move the data service containers to the official `python:3.12-slim-bookworm` image, which satisfies aiohttp 3.14's `>=3.10` requirement without a custom distro install-root flow.
- Clean up the data service Dockerfiles by using `python -m pip`, keeping runtime environment expansion explicit, and collapsing the ingest image back to a single stage now that the extra asset stage does not provide a meaningful benefit.
- Install the runtime download tools needed by ingest because `ingest.py` downloads extracts during normal operation.
- Verify the pinned `imposm3` release tarball with SHA256 before extracting it into the ingest image.
- Keep the data service aiohttp usage unchanged after checking for the documented 3.14 breaking-change surfaces; this service does not use `request.host`, construct `ClientResponse`, or emit dynamic/control-character headers.

## Validation
- `gh api graphql` advisory check for aiohttp security vulnerabilities
- `python3 -m pip index versions aiohttp`
- Python package resolution for `aiohttp==3.14.1` with `svcs/data` dependencies, including `requirements_kubernetes.txt`
- Import and route construction checks for `svcs/data/gentiles.py` and `svcs/data/utilities/random_tile_server.py`
- `docker build -f svcs/data/Dockerfile.tilesrv svcs/data -t soundscape-data-tilesrv:python-standard-check`
- `docker build -f svcs/data/Dockerfile.ingest svcs/data -t soundscape-data-ingest:python-standard-check`
- Container checks confirming Python `3.12.13` and aiohttp `3.14.1` in both built images
- `docker build -f svcs/data/Dockerfile.ingest svcs/data` after collapsing the ingest Dockerfile to one stage
- `docker build -f svcs/data/Dockerfile.ingest svcs/data` after adding `imposm3` SHA256 verification; build output confirmed `/tmp/imposm.tar.gz: OK`
- `timeout 900 docker compose up --build ingest` from `svcs/data`
- Confirmed the compose ingest downloaded the DC extract, provisioned PostGIS, imported OSM data, rotated tables, and loaded non-OSM test data
- Verified imported table counts: `osm_places=215720`, `osm_roads=93163`, `osm_entrances=704`, `non_osm_data=1`
- `curl http://127.0.0.1:8081/16/18745/25070.json` returned `HTTP 200` from `Python/3.12 aiohttp/3.14.1` with a `FeatureCollection` containing 1212 features
- `docker compose down` after the latest ingest validation
- `git diff --check`