### PR TITLE
[codex] Separate NaviLens location detail action

### DIFF
--- a/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-GB.lproj/Localizable.strings
@@ -1029,7 +1029,7 @@
 "location_detail.action.beacon" = "Start Audio Beacon";
 
 /*  */
-"location_detail.action.beacon_or_navilens" = "Start NaviLens or Audio Beacon";
+"location_detail.action.navilens" = "Open NaviLens";
 
 /*  */
 "location_detail.action.beacon.hint" = "Double tap to set an audio beacon at this location";
@@ -4499,7 +4499,7 @@
 "whats_new.1_8_2.1.title" = "NaviLens Suggestions Now Offer Separate Actions to Open NaviLens or Show Nearby Codes";
 "whats_new.1_8_2.1.description" = "";
 "beacon.action.navilens" = "Launch NaviLens";
-"location_detail.action.beacon_or_navilens.hint" = "Double tap to launch NaviLens or set an audio beacon, based on how close this location is";
+"location_detail.action.navilens.hint" = "Double tap to open NaviLens";
 "troubleshooting.tile_server_url.explanation" = "This is the server from which Soundscape retrieves map data. You normally should not need to change this unless you are developing or testing Soundscape.";
 "troubleshooting.tile_server_url" = "Tile Server URL";
 "troubleshooting.user_data" = "User Data";

--- a/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/en-US.lproj/Localizable.strings
@@ -921,14 +921,14 @@
 /* Title for the action to set a beacon */
 "location_detail.action.beacon" = "Start Audio Beacon";
 
-/* Text label for the action to start audio beacon at a NaviLens-enabled location */
-"location_detail.action.beacon_or_navilens" = "Start NaviLens or Audio Beacon";
+/* Text label for the action to open NaviLens */
+"location_detail.action.navilens" = "Open NaviLens";
 
 /* Voiceover hint for the action to set a beacon */
 "location_detail.action.beacon.hint" = "Double tap to set an audio beacon at this location";
 
-/* Voiceover hint for the action to set a beacon or launch NaviLens */
-"location_detail.action.beacon_or_navilens.hint" = "Double tap to launch NaviLens or set an audio beacon, based on how close this location is";
+/* Voiceover hint for the action to open NaviLens */
+"location_detail.action.navilens.hint" = "Double tap to open NaviLens";
 
 /* Text displayed when audio beacon action is disabled */
 "location_detail.action.beacon.hint.disabled" = "Setting a new audio beacon is disabled while route guidance is active";

--- a/apps/ios/GuideDogs/Assets/Localization/es-ES.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/es-ES.lproj/Localizable.strings
@@ -4454,9 +4454,9 @@
 "route_detail.action.start_reversed_route" = "Iniciar ruta de regreso";
 "faq.tip.reverse_route" = "Cuando selecciones \"Iniciar ruta de regreso\" en la pantalla \"Detalles de la ruta\", será más fácil tomar una ruta de regreso, y se guardará una copia de la ruta con los puntos en orden inverso. Ten en cuenta que \"Iniciar ruta de regreso\" no guardará otra copia de la ruta ya guardada.";
 "help.text.routes.content.how.1a" = "<b>Seguimiento de una ruta</b>:<br/> selecciona tu ruta en la página \"Marcadores y rutas\" y, a continuación, \"Iniciar ruta\". Volverás a la pantalla de inicio y Soundscape establecerá una señal en el primer punto de ruta. A medida que vayas por la ruta, la señal avanzará al siguiente punto hasta completar la ruta. Si en cualquier momento deseas saltar hacia delante o hacia atrás un punto de ruta, pulsa en \"Siguiente punto de ruta\" o \"Punto de ruta anterior\".";
-"location_detail.action.beacon_or_navilens.hint" = "Pulsa dos veces para iniciar NaviLens o establecer una señal de audio según qué tan cerca esté esta ubicación";
+"location_detail.action.navilens.hint" = "Pulsa dos veces para abrir NaviLens";
 "beacon.suggest_navilens" = "Usa el botón NaviLens para llegar a tu destino.";
-"location_detail.action.beacon_or_navilens" = "Iniciar NaviLens o señal de audio";
+"location_detail.action.navilens" = "Abrir NaviLens";
 "filter.navilens" = "Códigos NaviLens";
 "troubleshooting.user_data" = "Datos de usuario";
 "troubleshooting.user_data.button" = "Eliminar todos los marcadores y rutas";

--- a/apps/ios/GuideDogs/Assets/Localization/fa-IR.lproj/Localizable.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/fa-IR.lproj/Localizable.strings
@@ -612,12 +612,12 @@
 "location_detail.title.waypoint" = "جزئیات ایستگاه";
 /* Title for the action to set a beacon */
 "location_detail.action.beacon" = "شروع نشانهٔ صوتی";
-/* Text label for the action to start audio beacon at a NaviLens-enabled location */
-"location_detail.action.beacon_or_navilens" = "شروع NaviLens یا نشانهٔ صوتی";
+/* Text label for the action to open NaviLens */
+"location_detail.action.navilens" = "باز کردن NaviLens";
 /* Voiceover hint for the action to set a beacon */
 "location_detail.action.beacon.hint" = "برای تنظیم یک نشانهٔ صوتی در این مکان دو بار ضربه بزنید";
-/* Voiceover hint for the action to set a beacon or launch NaviLens */
-"location_detail.action.beacon_or_navilens.hint" = "بسته به نزدیکی این مکان، برای راه‌اندازی NaviLens یا تنظیم یک نشانهٔ صوتی دو بار ضربه بزنید";
+/* Voiceover hint for the action to open NaviLens */
+"location_detail.action.navilens.hint" = "برای باز کردن NaviLens دو بار ضربه بزنید";
 /* Text displayed when audio beacon action is disabled */
 "location_detail.action.beacon.hint.disabled" = "تنظیم یک نشانهٔ صوتی جدید در حین فعال بودن راهنمای مسیر غیرفعال است";
 /* Voiceover hint for the action to save marker */
@@ -2468,8 +2468,6 @@
 "donation.body" = "لطفاً با حمایت مالی در صفحه جمع‌آوری کمک‌های مالی ما، از توسعه مداوم برنامه جامعه Soundscape حمایت کنید. هر کمک مالی ما را یک قدم به چشم‌انداز خود نزدیک‌تر می‌کند تا به تحقق جهانی کمک کنیم که در آن همه از طریق فناوری بهبودبخش زندگی ما، دسترسی برابری به اطلاعات پیرامون خود داشته باشند.";
 /* Donation link title */
 "donation.link" = "رفتن به صفحه جمع‌آوری کمک‌های مالی";
-
-
 
 
 

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Integrations.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Integrations.swift
@@ -100,28 +100,3 @@ func launchNaviLensApp() {
 func launchNaviLens(detail: LocationDetail) {
     launchNaviLensApp()
 }
-
-func guideToNaviLens(detail: LocationDetail) throws {
-    // Launch NaviLens if close enough, otherwise start beacon
-    guard let location = AppContext.shared.geolocationManager.location else {
-        // Location is unknown
-        return launchNaviLens(detail: detail)
-    }
-
-    // If our GPS is more precise than we are close, use a beacon
-    if location.distance(from: detail.location) > location.horizontalAccuracy {
-        try LocationActionHandler.beacon(locationDetail: detail)
-    } else {
-        launchNaviLens(detail: detail)
-    }
-}
-
-func safeGuideToNaviLens(poi: POI) {
-    // Launch NaviLens if starting a beacon throws an error
-    let detail = LocationDetail(entity: poi)
-    do {
-        try guideToNaviLens(detail: detail)
-    } catch {
-        launchNaviLens(detail: detail)
-    }
-}

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Location/Location Action/LocationAction.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Location/Location Action/LocationAction.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -33,8 +34,7 @@ enum LocationAction {
     static func actions(for detail: LocationDetail) -> [LocationAction] {
         var result: [LocationAction] = [.beacon]
         if detail.source.hasNaviLens {
-            // NaviLens action replaces beacon action
-            result = [.navilens]
+            result.append(.navilens)
         }
         if detail.isMarker {
             result += [.edit, .preview, .share(isEnabled: true)]
@@ -76,7 +76,7 @@ enum LocationAction {
         case .beacon: return GDLocalizedString("location_detail.action.beacon")
         case .preview: return GDLocalizedString("preview.title")
         case .share: return GDLocalizedString("share.title")
-        case .navilens: return GDLocalizedString("location_detail.action.beacon_or_navilens")
+        case .navilens: return GDLocalizedString("location_detail.action.navilens")
         }
     }
     
@@ -87,7 +87,7 @@ enum LocationAction {
         case .beacon: return isEnabled ? GDLocalizedString("location_detail.action.beacon.hint") : GDLocalizedString("location_detail.action.beacon.hint.disabled")
         case .preview: return isEnabled ? GDLocalizedString("location_detail.action.preview.hint") : GDLocalizedString("location_detail.action.preview.hint.disabled")
         case .share(let isEnabled): return isEnabled ? GDLocalizedString("location_detail.action.share.hint") : GDLocalizedString("location_detail.disabled.share")
-        case .navilens: return GDLocalizedString("location_detail.action.beacon_or_navilens.hint")
+        case .navilens: return GDLocalizedString("location_detail.action.navilens.hint")
         }
     }
     

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Location/Location Detail/LocationDetail.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Location/Location Detail/LocationDetail.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -371,6 +372,11 @@ extension LocationDetail {
     init(location: CLLocation, imported: ImportedLocationDetail? = nil, telemetryContext: String? = nil) {
         let source: Source = .coordinate(at: location)
         self.init(source: source, location: location, centerLocation: location, estimated: nil, imported: imported, telemetryContext: telemetryContext)
+    }
+
+    init(screenshot poi: GenericLocation, imported: ImportedLocationDetail? = nil, telemetryContext: String? = nil) {
+        let source: Source = .screenshots(poi: poi)
+        self.init(source: source, location: poi.location, centerLocation: poi.location, estimated: nil, imported: imported, telemetryContext: telemetryContext)
     }
     
     init(entity: POI, imported: ImportedLocationDetail? = nil, telemetryContext: String? = nil) {

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/Home/HomeViewController.swift
@@ -695,9 +695,7 @@ extension HomeViewController: LocationActionDelegate {
                         self.present(firstUseAlert, animated: true, completion: nil)
                     }
                 case .navilens:
-                    // Set a beacon on the given location
-                    // and segue to the home view
-                    try guideToNaviLens(detail: detail)
+                    launchNaviLens(detail: detail)
                     self.navigationController?.popToRootViewController(animated: true)
                 }
             } catch let error as LocationActionError {

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/Location Detail/LocationDetailViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/Location Detail/LocationDetailViewController.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -345,13 +346,7 @@ extension LocationDetailViewController: LocationActionDelegate {
                         self.present(firstUseAlert, animated: true, completion: nil)
                     }
                 case .navilens:
-                    // Set a beacon on the given location
-                    // and segue to the home view
-                    try guideToNaviLens(detail: detail)
-                    
-                    if let home = self.navigationController?.viewControllers.first as? HomeViewController {
-                        home.shouldFocusOnBeacon = true
-                    }
+                    launchNaviLens(detail: detail)
                     
                     if self.isPresentedModally && !self.isInPreviewController {
                         self.dismiss(animated: true)

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/NearbyTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/NearbyTableViewController.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -376,9 +377,7 @@ extension NearbyTableViewController: LocationAccessibilityActionDelegate {
                         self.present(firstUseAlert, animated: true, completion: nil)
                     }
                 case .navilens:
-                    // Set a beacon on the given location
-                    // and segue to the home view
-                    try guideToNaviLens(detail: detail)
+                    launchNaviLens(detail: detail)
                     self.navigationController?.popToRootViewController(animated: true)
                 }
                 

--- a/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/SearchTableViewController.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/View Controllers/POI Table/SearchTableViewController.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -353,9 +354,7 @@ extension SearchTableViewController: LocationActionDelegate {
                         self.present(firstUseAlert, animated: true, completion: nil)
                     }
                 case .navilens:
-                    // Set a beacon on the given location
-                    // and segue to the home view
-                    try guideToNaviLens(detail: detail)
+                    launchNaviLens(detail: detail)
                     self.navigationController?.popToRootViewController(animated: true)
                 }
             } catch let error as LocationActionError {

--- a/apps/ios/GuideDogs/Code/Visual UI/Views/Markers & Routes/MarkersAndRoutesListNavigationHelper.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Views/Markers & Routes/MarkersAndRoutesListNavigationHelper.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -88,9 +89,7 @@ class MarkersAndRoutesListNavigationHelper: ViewNavigationHelper, LocationAccess
                     }
 
                 case .navilens:
-                    // Set a beacon on the given location
-                    // and segue to the home view
-                    try guideToNaviLens(detail: detail)
+                    launchNaviLens(detail: detail)
                     self.popToRootViewController(animated: true)
                 }
             } catch let error as LocationActionError {

--- a/apps/ios/UnitTests/Data/Destination Manager/NearbyTableFilterTest.swift
+++ b/apps/ios/UnitTests/Data/Destination Manager/NearbyTableFilterTest.swift
@@ -63,4 +63,48 @@ final class NearbyTableFilterTest: XCTestCase {
         XCTAssertEqual(filter1, filter2)
         XCTAssertNotEqual(filter1, filter3)
     }
+
+    func testLocationActionsExcludeNaviLensForStandardLocation() throws {
+        let location = GenericLocation(lat: 47.6205, lon: -122.3493, name: "Space Needle")
+        let detail = LocationDetail(screenshot: location)
+
+        let actions = LocationAction.actions(for: detail)
+
+        XCTAssertTrue(matches(actions[0], .beacon))
+        XCTAssertFalse(actions.contains(where: { matches($0, .navilens) }))
+    }
+
+    func testLocationActionsPlaceNaviLensAfterBeacon() throws {
+        let location = GenericLocation(lat: 47.6205, lon: -122.3493, name: "NaviLens Code")
+        location.superCategory = SuperCategory.navilens.rawValue
+        let detail = LocationDetail(screenshot: location)
+
+        let actions = LocationAction.actions(for: detail)
+
+        XCTAssertEqual(actions.count, 5)
+        XCTAssertTrue(matches(actions[0], .beacon))
+        XCTAssertTrue(matches(actions[1], .navilens))
+        XCTAssertTrue(matches(actions[2], .save(isEnabled: true)))
+        XCTAssertTrue(matches(actions[3], .preview))
+        XCTAssertTrue(matches(actions[4], .share(isEnabled: true)))
+        XCTAssertEqual(LocationAction.navilens.text, "Open NaviLens")
+        XCTAssertEqual(LocationAction.navilens.accessibilityHint, "Double tap to open NaviLens")
+        XCTAssertFalse(LocationAction.navilens.accessibilityHint?.contains("beacon") ?? true)
+    }
+
+    private func matches(_ lhs: LocationAction, _ rhs: LocationAction) -> Bool {
+        switch (lhs, rhs) {
+        case (.save(let lhsEnabled), .save(let rhsEnabled)):
+            return lhsEnabled == rhsEnabled
+        case (.edit, .edit),
+             (.beacon, .beacon),
+             (.preview, .preview),
+             (.navilens, .navilens):
+            return true
+        case (.share(let lhsEnabled), .share(let rhsEnabled)):
+            return lhsEnabled == rhsEnabled
+        default:
+            return false
+        }
+    }
 }

--- a/apps/ios/UnitTests/Data/Destination Manager/NearbyTableFilterTest.swift
+++ b/apps/ios/UnitTests/Data/Destination Manager/NearbyTableFilterTest.swift
@@ -87,9 +87,8 @@ final class NearbyTableFilterTest: XCTestCase {
         XCTAssertTrue(matches(actions[2], .save(isEnabled: true)))
         XCTAssertTrue(matches(actions[3], .preview))
         XCTAssertTrue(matches(actions[4], .share(isEnabled: true)))
-        XCTAssertEqual(LocationAction.navilens.text, "Open NaviLens")
-        XCTAssertEqual(LocationAction.navilens.accessibilityHint, "Double tap to open NaviLens")
-        XCTAssertFalse(LocationAction.navilens.accessibilityHint?.contains("beacon") ?? true)
+        XCTAssertEqual(LocationAction.navilens.text, GDLocalizedString("location_detail.action.navilens"))
+        XCTAssertEqual(LocationAction.navilens.accessibilityHint, GDLocalizedString("location_detail.action.navilens.hint"))
     }
 
     private func matches(_ lhs: LocationAction, _ rhs: LocationAction) -> Bool {


### PR DESCRIPTION
## Summary

Separates NaviLens from the audio beacon location-detail action so NaviLens-enabled locations show both actions instead of replacing the beacon action.

## Changes

- Adds NaviLens as its own location action after the audio beacon action.
- Updates location-detail callers to use the separate NaviLens action path.
- Removes the old integration helper behavior that combined beacon and NaviLens handling.
- Updates English, Spanish, and Persian localized strings for the new standalone NaviLens action.
- Adds unit coverage for standard and NaviLens-enabled location action ordering.

## Validation

- Passed: `UnitTests/NearbyTableFilterTest` on iPhone 17 simulator via XcodeBuildMCP, 5 tests passed.

## Notes

The test run reported existing localization formatting warnings in `en-US.lproj/Localizable.strings`; no test failures were reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * NaviLens is now available as a dedicated action option.
  * Added support for screenshot-based location details.

* **Improvements**
  * Enhanced localization strings for NaviLens functionality across multiple languages (English, Spanish, and Persian).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->