### PR TITLE
Fix Soundscape route imports

### DIFF
--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 		914BAAF32AD745E400CB2171 /* DestinationManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914BAAF22AD745E400CB2171 /* DestinationManagerTest.swift */; };
 		914BAAFD2AD7483300CB2171 /* AudioEngineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914BAAFC2AD7483300CB2171 /* AudioEngineTest.swift */; };
 		914BAB012AD7490100CB2171 /* NavigationControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914BAB002AD7490100CB2171 /* NavigationControllerTest.swift */; };
+		D4A72B0131A1000100C0FFEE /* URLResourceIdentifierTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A72B0031A1000100C0FFEE /* URLResourceIdentifierTest.swift */; };
 		915FF9F62ADE4BAF002B3690 /* AuthoredActivityContentTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915FF9F42ADE3F91002B3690 /* AuthoredActivityContentTest.swift */; };
 		91C82AAD2A5DCF040086D126 /*  GeolocationManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C82AAC2A5DCF040086D126 /*  GeolocationManagerTest.swift */; };
 		91C82ABE2A6B08500086D126 /* RouteGuidanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C82ABD2A6B08500086D126 /* RouteGuidanceTest.swift */; };
@@ -1320,6 +1321,7 @@
 		914BAAF22AD745E400CB2171 /* DestinationManagerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationManagerTest.swift; sourceTree = "<group>"; };
 		914BAAFC2AD7483300CB2171 /* AudioEngineTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioEngineTest.swift; sourceTree = "<group>"; };
 		914BAB002AD7490100CB2171 /* NavigationControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationControllerTest.swift; sourceTree = "<group>"; };
+		D4A72B0031A1000100C0FFEE /* URLResourceIdentifierTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLResourceIdentifierTest.swift; sourceTree = "<group>"; };
 		914DEBCD2A3CE6B9007B161C /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryUtilsTest.swift; sourceTree = "<group>"; };
 		915FF9F42ADE3F91002B3690 /* AuthoredActivityContentTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthoredActivityContentTest.swift; sourceTree = "<group>"; };
@@ -3526,6 +3528,7 @@
 				914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */,
 				20EB7956C9AA4CB8A103128F /* NaviLensWakeOnForegroundTest.swift */,
 				914BAB002AD7490100CB2171 /* NavigationControllerTest.swift */,
+				D4A72B0031A1000100C0FFEE /* URLResourceIdentifierTest.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -4725,6 +4728,7 @@
 				91DC0CF92A46134600244CC8 /* GeometryUtilsTest.swift in Sources */,
 				666CA3EAAA904E6EBFA10A53 /* NaviLensWakeOnForegroundTest.swift in Sources */,
 				914BAB012AD7490100CB2171 /* NavigationControllerTest.swift in Sources */,
+				D4A72B0131A1000100C0FFEE /* URLResourceIdentifierTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/GuideDogs/Assets/PropertyLists/Info.plist
+++ b/apps/ios/GuideDogs/Assets/PropertyLists/Info.plist
@@ -16,28 +16,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>services.soundscape.doc</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeName</key>
-			<string>Microsoft Soundscape app route and marker file</string>
-			<key>LSHandlerRank</key>
-			<string>Owner</string>
-			<key>LSItemContentTypes</key>
-			<array>
 				<string>com.microsoft.soundscape.doc</string>
-			</array>
-			<key>NSExportableTypes</key>
-			<string>NSExportableTypes</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeName</key>
-			<string>Openscape route and marker file</string>
-			<key>LSHandlerRank</key>
-			<string>Default</string>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>io.openscape.doc</string>
 			</array>
 		</dict>
 	</array>
@@ -183,12 +162,12 @@
 			<key>UTTypeIconFiles</key>
 			<array/>
 			<key>UTTypeIdentifier</key>
-			<string>io.openscape.doc</string>
+			<string>services.soundscape.doc</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
-					<string>openscape</string>
+					<string>soundscape</string>
 				</array>
 			</dict>
 		</dict>
@@ -212,46 +191,6 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>soundscape</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.content</string>
-				<string>public.data</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>Soundscape route and marker file</string>
-			<key>UTTypeIconFiles</key>
-			<array/>
-			<key>UTTypeIdentifier</key>
-			<string>services.soundscape.doc</string>
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>public.filename-extension</key>
-				<array>
-					<string>soundscape</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.content</string>
-				<string>public.data</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>Openscape route and marker file</string>
-			<key>UTTypeIconFiles</key>
-			<array/>
-			<key>UTTypeIdentifier</key>
-			<string>io.openscape.doc</string>
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>public.filename-extension</key>
-				<array>
-					<string>openscape</string>
 				</array>
 			</dict>
 		</dict>

--- a/apps/ios/GuideDogs/Code/App/App Delegate/AppDelegate.swift
+++ b/apps/ios/GuideDogs/Code/App/App Delegate/AppDelegate.swift
@@ -49,10 +49,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             pushNotificationManager.didFinishLaunchingWithOptions(launchOptions)
         }
 
-        if let url = launchOptions?[.url] as? URL {
-            return openURLResource(url)
-        }
-        
         return true
     }
 

--- a/apps/ios/GuideDogs/Code/App/App Delegate/AppDelegate.swift
+++ b/apps/ios/GuideDogs/Code/App/App Delegate/AppDelegate.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -47,6 +48,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let launchOptions = launchOptions {
             pushNotificationManager.didFinishLaunchingWithOptions(launchOptions)
         }
+
+        if let url = launchOptions?[.url] as? URL {
+            return openURLResource(url)
+        }
         
         return true
     }
@@ -56,6 +61,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        return openURLResource(url)
+    }
+
+    private func openURLResource(_ url: URL) -> Bool {
+        GDLogAppInfo("Application asked to open file: \(url.lastPathComponent)")
+
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: true){
            if let source = components.queryItems?.first(where: { $0.name == "source" })?.value {
             GDLogAppInfo("App opened from source: \(source)")

--- a/apps/ios/GuideDogs/Code/App/App Delegate/URL Resources/Identifiers/URLResourceIdentifier.swift
+++ b/apps/ios/GuideDogs/Code/App/App Delegate/URL Resources/Identifiers/URLResourceIdentifier.swift
@@ -3,18 +3,19 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
-import Foundation
+enum URLResourceIdentifier {
+    case gpx
+    case route
 
-enum URLResourceIdentifier: String {
-    /*
-     Important!
-     
-     `URLResourceIdentifier` raw value should be the document type identifier and should match the identifier provided in the Info.plist (`Imported Type Identifiers` and `Exported Type Identifiers`)
-     */
-    case gpx = "com.topografix.gpx"
-    case route = "services.soundscape.doc"
-    case openscape_route = "io.openscape.doc"
+    init?(pathExtension: String) {
+        switch pathExtension.lowercased() {
+        case "gpx": self = .gpx
+        case "soundscape": self = .route
+        default: return nil
+        }
+    }
 }

--- a/apps/ios/GuideDogs/Code/App/App Delegate/URL Resources/URLResourceManager.swift
+++ b/apps/ios/GuideDogs/Code/App/App Delegate/URL Resources/URLResourceManager.swift
@@ -3,6 +3,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -59,16 +60,15 @@ class URLResourceManager {
      Delegates URL resources to the appropriate handler.
      
      Returns TRUE if the resource type is supported by the app and has a corresponding handler
-     Returns FALSE if the resource type is not supported
+    Returns FALSE if the resource type is not supported
      */
     func onOpenResource(from url: URL) -> Bool {
-        guard let iRawValue = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier else {
+        guard let identifier = URLResourceIdentifier(pathExtension: url.pathExtension) else {
+            GDLogURLResourceError("Unsupported incoming file: \(url.lastPathComponent)")
             return false
         }
-        
-        guard let identifier = URLResourceIdentifier(rawValue: iRawValue) else {
-            return false
-        }
+
+        GDLogURLResourceVerbose("Opening incoming file: \(url.lastPathComponent)")
         
         queue.async { [weak self] in
             guard let `self` = self else {
@@ -93,7 +93,6 @@ class URLResourceManager {
         switch resource.identifier {
         case .gpx: handler = gpxHandler
         case .route: handler = routeHandler
-        case .openscape_route: handler = routeHandler
         }
         
         handler.handleURLResource(with: resource.url)

--- a/apps/ios/UnitTests/App/Helpers/URLResourceIdentifierTest.swift
+++ b/apps/ios/UnitTests/App/Helpers/URLResourceIdentifierTest.swift
@@ -1,0 +1,37 @@
+//
+//  URLResourceIdentifierTest.swift
+//  UnitTests
+//
+//  Copyright (c) Soundscape Community Contributors.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+@testable import Soundscape
+
+class URLResourceIdentifierTest: XCTestCase {
+
+    func testRecognizesSoundscapeExtension() {
+        let identifier = URLResourceIdentifier(pathExtension: "soundscape")
+
+        XCTAssertEqual(identifier, .route)
+    }
+
+    func testRecognizesSoundscapeExtensionCaseInsensitively() {
+        let identifier = URLResourceIdentifier(pathExtension: "Soundscape")
+
+        XCTAssertEqual(identifier, .route)
+    }
+
+    func testRejectsUnknownExtension() {
+        let identifier = URLResourceIdentifier(pathExtension: "json")
+
+        XCTAssertNil(identifier)
+    }
+
+    func testDoesNotRecognizeRemovedOpenscapeExtension() {
+        let identifier = URLResourceIdentifier(pathExtension: "openscape")
+
+        XCTAssertNil(identifier)
+    }
+}


### PR DESCRIPTION
## What changed

- register both the current community and legacy Microsoft Soundscape document UTIs
- classify incoming documents by the `.soundscape` filename extension, independent of the UTI supplied by another app
- funnel incoming document URLs through one shared handler
- add useful incoming-file diagnostics
- remove obsolete Openscape registration and handling
- add focused extension-classification regression tests

## Why

The app advertised the legacy Microsoft document type in `Info.plist`, but its runtime identifier enum did not recognize that UTI. The resource manager silently returned `false`, so shared routes were ignored.

## User impact

Soundscape can again be selected for `.soundscape` routes created by both the community app and Microsoft Soundscape, and accepted document URLs are handled consistently regardless of the UTI reported by the source app.

## Validation

- `plutil -lint` on `Info.plist` and the Xcode project
- `git diff --check`
- iOS test bundle built successfully for an iOS 26.4 simulator
- `URLResourceIdentifierTest`: 4 tests passed