### PR TITLE
Add Latin American Spanish localization support

### DIFF
--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -1208,6 +1208,8 @@
 		6258B3892469DB220051F60B /* UniversalLinkVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UniversalLinkVersion.swift; path = "Code/App/App Delegate/User Activities/Universal Links/Components/UniversalLinkVersion.swift"; sourceTree = "<group>"; };
 		6258B39124732D590051F60B /* es-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-ES"; path = "es-ES.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		6258B39224732D590051F60B /* es-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-ES"; path = "es-ES.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		E54190012E5F000100000001 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		E54190022E5F000100000002 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		6258B39324732D840051F60B /* fr-FR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fr-FR"; path = "fr-FR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		6258B39424732D840051F60B /* fr-FR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fr-FR"; path = "fr-FR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		6258B39524732D8D0051F60B /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -4531,6 +4533,7 @@
 				"en-GB",
 				"fr-CA",
 				"es-ES",
+				"es-419",
 				"fr-FR",
 				"pt-BR",
 				"de-DE",
@@ -5371,6 +5374,7 @@
 				316B3F70228392850025526D /* fr-CA */,
 				C3FA2F02236B557F00ADB8BC /* sv-SE */,
 				6258B39124732D590051F60B /* es-ES */,
+				E54190022E5F000100000002 /* es-419 */,
 				6258B39324732D840051F60B /* fr-FR */,
 				6258B39624732D8D0051F60B /* pt-BR */,
 				B9978B9725DDBE80005DA642 /* de-DE */,
@@ -5396,6 +5400,7 @@
 				319688E6222EF3280009DA69 /* fr-CA */,
 				C3FA2F03236B557F00ADB8BC /* sv-SE */,
 				6258B39224732D590051F60B /* es-ES */,
+				E54190012E5F000100000001 /* es-419 */,
 				6258B39424732D840051F60B /* fr-FR */,
 				6258B39524732D8D0051F60B /* pt-BR */,
 				B9978B9625DDBE73005DA642 /* de-DE */,

--- a/apps/ios/GuideDogs/Assets/Localization/es-419.lproj/InfoPlist.strings
+++ b/apps/ios/GuideDogs/Assets/Localization/es-419.lproj/InfoPlist.strings
@@ -1,0 +1,7 @@
+/*
+  InfoPlist.strings
+  GuideDogs
+
+  Copyright (c) Soundscape Community Contributors.
+  Licensed under the MIT License.
+*/

--- a/apps/ios/Scripts/LocalizationLinter/main.swift
+++ b/apps/ios/Scripts/LocalizationLinter/main.swift
@@ -5,6 +5,7 @@
 //  Soundscape
 //
 //  Copyright (c) Microsoft Corporation.
+//  Copyright (c) Soundscape Community Contributors.
 //  Licensed under the MIT License.
 //
 
@@ -305,10 +306,13 @@ class StringsFile: File {
     
     // MARK: Constants
     
-    // Match:
+    // Match either:
     // /* comment */
     // "key" = "string";
-    static let regexPattern = "\\/\\* (?<comment>.*?) \\*\\/\n\"(?<key>.*?)\" = \"(?<value>.*?)\";"
+    //
+    // Or Weblate-generated entries without comments:
+    // "key" = "string";
+    static let regexPattern = "(?:\\/\\* (?<comment>.*?) \\*\\/\n)?\"(?<key>.*?)\" = \"(?<value>.*?)\";"
     
     static let wordCountRegex = "\\W*\\w+\\W*"
     
@@ -394,11 +398,15 @@ class StringsFile: File {
         let matches = NSRegularExpression.matches(pattern: StringsFile.regexPattern, in: content)
         
         let translations = matches.compactMap { (match) -> Translation? in
-            guard let commentRange = Range(match.range(withName: "comment"), in: content) else { return nil }
             guard let keyRange = Range(match.range(withName: "key"), in: content) else { return nil }
             guard let valueRange = Range(match.range(withName: "value"), in: content) else { return nil }
             
-            let comment = String(content[commentRange])
+            let comment: String
+            if let commentRange = Range(match.range(withName: "comment"), in: content) {
+                comment = String(content[commentRange])
+            } else {
+                comment = ""
+            }
             let key = String(content[keyRange])
             let value = String(content[valueRange])
             


### PR DESCRIPTION
## Summary

- register Latin American Spanish as `es-419` in the Xcode project
- add empty `Localizable.strings` and `InfoPlist.strings` placeholders so the project builds before translations land
- update the localization linter to parse Weblate-generated `.strings` entries that omit comments

## Why

Hosted Weblate now has a Latin American Spanish translation. This prepares the iOS project to build the correctly named `es-419.lproj` resources without copying Weblate-managed translations into this PR.

## Validation

- `swift Scripts/LocalizationLinter/main.swift`
- `xcodebuild build-for-testing` on an iPhone 17 Pro / iOS 26.4 simulator
- 66 unit tests passed with `xcodebuild test-without-building`
- `plutil -lint` passed for the Xcode project and `InfoPlist.strings`

## Follow-up

After this merges, refresh or rebase the Weblate PR before merging it so its generated translations replace the empty `Localizable.strings` placeholder cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spanish (Latin America) localization support for the iOS app.

* **Bug Fixes**
  * Improved localization validation to recognize translated entries without accompanying comments.

* **Documentation**
  * Added licensing and file-purpose information to the Spanish app metadata localization file.
  * Updated script attribution to reflect community contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->